### PR TITLE
 Allow locally imported certificates to be renewed

### DIFF
--- a/Certman.class.php
+++ b/Certman.class.php
@@ -1213,7 +1213,7 @@ class Certman implements \BMO {
 		$processed = array();
 		foreach(glob($location."/*.key") as $file) {
 			$name = basename($file,".key");
-			if(in_array(basename($file),$cas) || $this->checkCertificateName($name)) {
+			if(in_array(basename($file),$cas)) {
 				continue;
 			}
 			$raw = file_get_contents($file);
@@ -1260,18 +1260,28 @@ class Certman implements \BMO {
 			foreach($keys as $key) {
 				if (openssl_x509_check_private_key($info, $key['res'])) {
 					$name = basename($file,".crt");
-					if(!$this->checkCertificateName($name)) {
-						try {
-							$status = $this->importCertificate($name,$key['raw'],file_get_contents($file));
-						} catch(\Exception $e) {
-							$processed[] = array(
-								"status" => false,
-								"error" => $e->getMessage(),
-								"file" => $file
-							);
-							continue;
-						}
-						$this->saveCertificate(null,$name,_("Imported from file system"),'up');
+					try {
+						$status = $this->importCertificate($name,$key['raw'],file_get_contents($file));
+					} catch(\Exception $e) {
+						$processed[] = array(
+							"status" => false,
+							"error" => $e->getMessage(),
+							"file" => $file
+						);
+						continue;
+					}
+					$success = false;
+					if($this->checkCertificateName($name)) {
+                        $oldDetails = $this->getCertificateDetailsByBasename($name);
+                        if (!empty($oldDetails) && $oldDetails['type'] == 'up') {
+                            $this->updateCertificate($oldDetails,_("Imported from file system"));
+                            $success = true;
+                        }
+                    } else {
+                        $this->saveCertificate(null,$name,_("Imported from file system"),'up');
+                        $success = true;
+                    }
+					if ($success) {
 						$processed[] = array(
 							"status" => true,
 							"file" => $file

--- a/Certman.class.php
+++ b/Certman.class.php
@@ -1272,15 +1272,15 @@ class Certman implements \BMO {
 					}
 					$success = false;
 					if($this->checkCertificateName($name)) {
-                        $oldDetails = $this->getCertificateDetailsByBasename($name);
-                        if (!empty($oldDetails) && $oldDetails['type'] == 'up') {
-                            $this->updateCertificate($oldDetails,_("Imported from file system"));
-                            $success = true;
-                        }
-                    } else {
-                        $this->saveCertificate(null,$name,_("Imported from file system"),'up');
-                        $success = true;
-                    }
+						$oldDetails = $this->getCertificateDetailsByBasename($name);
+						if (!empty($oldDetails) && $oldDetails['type'] == 'up') {
+							$this->updateCertificate($oldDetails,_("Imported from file system"));
+							$success = true;
+						}
+					} else {
+						$this->saveCertificate(null,$name,_("Imported from file system"),'up');
+						$success = true;
+					}
 					if ($success) {
 						$processed[] = array(
 							"status" => true,

--- a/Console/Certman.class.php
+++ b/Console/Certman.class.php
@@ -129,7 +129,7 @@ class Certman extends Command {
 			$list = $certman->importLocalCertificates();
 			if(empty($list)) {
 				$loc = $pkcs->getKeysLocation();
-				$output->writeln(_("<info>".sprintf(_("No Certificates to import. Try placing a certificate (<name>.crt) and its key (<name>.crt) into %s"),$loc)."</info>"));
+				$output->writeln(_("<info>".sprintf(_("No Certificates to import. Try placing a certificate (<name>.crt) and its key (<name>.key) into %s"),$loc)."</info>"));
 				exit(4);
 			}
 			$err = false;


### PR DESCRIPTION
This PR allows locally imported certificates to be renewed. There is currently no automated way to do this. After this change, you can replace the relevant .crt and .key files, set appropriate ownership and permissions on the new files, and run `fwconsole certificates --import`. All locally imported certs will be updated.

Feedback is welcome. It's working as expected in my testing, but I'm not super familiar with all the code here, so there may be unintended side effects from my approach. For example, after this change is made, all local certs are re-imported anytime an import is requested (via the GUI or CLI) whether or not their cert files have changed. I didn't see a good way to limit this without significant changes (e.g. store file modification times in the DB), so I decided to start here and see what feedback there is.

I'm happy to fill out a CLA if necessary.

See [this forum thread](https://community.freepbx.org/t/how-to-renew-a-locally-imported-cert/50288) for more discussion.

Fixes: https://issues.freepbx.org/browse/FREEPBX-17633