### PR TITLE
Switch from Cron to Job class

### DIFF
--- a/Certman.class.php
+++ b/Certman.class.php
@@ -86,6 +86,13 @@ class Certman implements BMO {
 				//return false;
 			}
 		}
+		
+		//delete Cron deprecated since 15.0.12 -> https://sangomakb.atlassian.net/wiki/spaces/FP/pages/10518892/Cron
+		$this->removeCronJob();
+
+		//register Job with random timing
+		$this->FreePBX->Job()->addClass('certman', 'update', 'FreePBX\modules\Certman\Job', rand(0, 59) . ' ' . rand(0, 3) . ' * * *');
+		
 		return true;
 	}
 
@@ -94,6 +101,7 @@ class Certman implements BMO {
 			$this->removeCSR();
 			$this->removeCA();
 			$this->removeCronJob();
+			//Jobs are automatically removed by freepbx
 			$certs = $this->getAllManagedCertificates();
 			foreach($certs as $cert) {
 				$this->removeCertificate($cert['cid']);

--- a/Job.php
+++ b/Job.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace FreePBX\modules\Certman;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
+
+class Job implements \FreePBX\Job\TaskInterface
+{
+	public static function run(InputInterface $input, OutputInterface $output)
+	{
+		$output->writeln("Starting Certman update check...");
+
+		$certman = \FreePBX::Certman();
+
+		//copied straight from the Console class (updateall)
+		$messages = $certman->checkUpdateCertificates();
+		$hints = array();
+		foreach ($messages as $message) {
+			if (!empty($message['hints'])) {
+				$hints = array_merge($hints, $message['hints']);
+			}
+			if ($message['type'] == "danger") {
+				$danger = true;
+			}
+		}
+		if ($danger) {
+			$certman->showhints($certman, $output, array_unique($hints));
+		}
+		foreach ($messages as $message) {
+			$m = $message['message'];
+			switch ($message['type']) {
+				case "danger":
+					$output->writeln("<error>" . $m . "</error>");
+					break;
+				case "warning":
+					$output->writeln("<comment>" . $m . "</comment>");
+					break;
+				case "success":
+					$output->writeln("<info>" . $m . "</info>");
+					break;
+			}
+		}
+
+		$output->writeln("Finished");
+		return true;
+	}
+}

--- a/install.php
+++ b/install.php
@@ -1,22 +1,5 @@
 <?php
 
-$ampsbin = FreePBX::Config()->get("AMPSBIN");
-foreach(FreePBX::Cron()->getAll() as $cron) {
-	$str = "fwconsole certificates updateall -q";
-	if(preg_match("/".$str."/i",$cron,$matches)) {
-		FreePBX::Cron()->remove($cron);
-	}
-	$str = "fwconsole certificates --updateall -q";
-	if(preg_match("/".$str."/i",$cron,$matches)) {
-		FreePBX::Cron()->remove($cron);
-	}
-}
-FreePBX::Cron()->add(array(
-	"command" => $ampsbin."/fwconsole certificates --updateall -q 2>&1 >/dev/null",
-	"hour" => rand(0,3),
-	"minute" => rand(0,59),
-));
-
 $freepbx_conf = freepbx_conf::create();
 $set['value'] = '730';
 $set['defaultval'] =& $set['value'];


### PR DESCRIPTION
This is a repost of the same PR made in Jira.

Following a problem I had with certman failing to renew certificates because its crontab was not executed, I noticed that certman is still using the long deprecated Cron class. This PR fixes the behavior by switching to the standard Job class.