### PR TITLE
don't create existing directories

### DIFF
--- a/Restore.php
+++ b/Restore.php
@@ -14,7 +14,9 @@ class Restore Extends Base\RestoreBase{
 		$originalKeyDir = $configs['keyDir'];
 		foreach ($dirs as $dir) {
 			$dir = str_Replace($originalKeyDir,$keyDir,$dir->getPathTo());
-			@mkdir($dir,0755,true);
+			if (!file_exists($dir)) {
+				mkdir($dir,0755,true);
+			}
 		}
 		foreach ($files as $file) {
 			$backupFilename = $file->getPathTo() . '/' . $file->getFilename();


### PR DESCRIPTION
Resolves warnings seen during restore:
```none
PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/certman/Restore.php on line 17

PHP Warning: mkdir(): File exists in /var/www/html/admin/modules/certman/Restore.php on line 17
```