### PR TITLE
feat: Private ACME server support, installed-CA viewer, and CA install into the system trust store (freepbx 16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 assets/less/cache
 module.sig
+ca-staging

--- a/Acme/AcmeHttpClient.php
+++ b/Acme/AcmeHttpClient.php
@@ -1,0 +1,141 @@
+<?php
+// vim: set ai ts=4 sw=4 ft=php:
+//	License for all code of this FreePBX module can be found in the license file inside the module directory
+namespace FreePBX\modules\Certman;
+
+use Analogic\ACME\ClientInterface;
+use RuntimeException;
+
+/**
+ * ACME HTTP client for private / self-hosted Let's Encrypt-compatible servers.
+ *
+ * It mirrors \Analogic\ACME\Client (the default lescript transport) but adds the
+ * pieces needed to talk to an internal ACME server using http-01:
+ *
+ *   - An explicit directory URL. lescript always requests the directory through
+ *     the relative path '/directory', but private servers expose it elsewhere
+ *     (step-ca: /acme/<provisioner>/directory, Pebble: /dir, ...). When a
+ *     directory URL is configured we substitute it for that relative request.
+ *   - An optional custom CA bundle (CURLOPT_CAINFO) for servers presenting a
+ *     certificate signed by a private CA.
+ *   - An optional insecure mode that skips TLS verification for self-signed
+ *     setups. Off by default; only used when the operator explicitly opts in.
+ *
+ * Keeping this in the module (rather than patching vendor/) means a composer
+ * update of analogic/lescript will not wipe the customisation.
+ */
+#[\AllowDynamicProperties]
+class AcmeHttpClient implements ClientInterface
+{
+	private $lastCode;
+	private $lastHeader;
+	private $base;
+	private $directoryUrl;
+	private $caBundle;
+	private $insecure;
+
+	/**
+	 * @param string      $base         Origin (scheme://host[:port]) used for any relative request
+	 * @param string|null $directoryUrl Full ACME directory URL (substituted for lescript's '/directory')
+	 * @param string|null $caBundle     Path to a PEM CA bundle that signs the ACME server certificate
+	 * @param bool        $insecure     Skip TLS verification of the ACME server (self-signed)
+	 */
+	public function __construct($base, $directoryUrl = null, $caBundle = null, $insecure = false)
+	{
+		$this->base = rtrim((string)$base, '/');
+		$this->directoryUrl = $directoryUrl;
+		$this->caBundle = $caBundle;
+		$this->insecure = (bool)$insecure;
+	}
+
+	private function curl($method, $url, $data = null)
+	{
+		// lescript always fetches the directory via the relative path '/directory'.
+		// Private servers expose it on non-standard paths, so honour the explicit URL.
+		if ($url === '/directory' && !empty($this->directoryUrl)) {
+			$url = $this->directoryUrl;
+		}
+
+		$headers = array('Accept: application/json', 'Content-Type: application/jose+json');
+		$handle = curl_init();
+		curl_setopt($handle, CURLOPT_URL, preg_match('~^http~', $url) ? $url : $this->base.$url);
+		curl_setopt($handle, CURLOPT_HTTPHEADER, $headers);
+		curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($handle, CURLOPT_HEADER, true);
+
+		if (!empty($this->caBundle)) {
+			curl_setopt($handle, CURLOPT_CAINFO, $this->caBundle);
+		}
+		if ($this->insecure) {
+			curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, 0);
+			curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, false);
+		}
+
+		switch ($method) {
+			case 'GET':
+				break;
+			case 'POST':
+				curl_setopt($handle, CURLOPT_POST, true);
+				curl_setopt($handle, CURLOPT_POSTFIELDS, $data);
+				break;
+		}
+		$response = curl_exec($handle);
+
+		if (curl_errno($handle)) {
+			throw new RuntimeException('Curl: '.curl_error($handle));
+		}
+
+		$header_size = curl_getinfo($handle, CURLINFO_HEADER_SIZE);
+
+		$header = substr($response, 0, $header_size);
+		$body = substr($response, $header_size);
+
+		$this->lastHeader = $header;
+		$this->lastCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+
+		if ($this->lastCode >= 400 && $this->lastCode < 600) {
+			throw new RuntimeException($this->lastCode."\n".$body);
+		}
+
+		$data = json_decode($body, true);
+		return $data === null ? $body : $data;
+	}
+
+	public function post($url, $data)
+	{
+		return $this->curl('POST', $url, $data);
+	}
+
+	public function get($url)
+	{
+		return $this->curl('GET', $url);
+	}
+
+	public function getLastNonce()
+	{
+		if (preg_match('~Replay-Nonce: (.+)~i', $this->lastHeader, $matches)) {
+			return trim($matches[1]);
+		}
+
+		throw new RuntimeException("We don't have nonce");
+	}
+
+	public function getLastLocation()
+	{
+		if (preg_match('~Location: (.+)~i', $this->lastHeader, $matches)) {
+			return trim($matches[1]);
+		}
+		return null;
+	}
+
+	public function getLastCode()
+	{
+		return $this->lastCode;
+	}
+
+	public function getLastLinks()
+	{
+		preg_match_all('~Link: <(.+)>;rel="up"~', $this->lastHeader, $matches);
+		return $matches[1];
+	}
+}

--- a/Certman.class.php
+++ b/Certman.class.php
@@ -129,6 +129,22 @@ class Certman implements BMO {
 		$request = $_REQUEST;
 		$request['certaction'] = !empty($request['certaction']) ? $request['certaction'] : "";
 		switch($request['certaction']) {
+			case "installca":
+				$pem = '';
+				if (!empty($_FILES['ca_file']['tmp_name']) && is_uploaded_file($_FILES['ca_file']['tmp_name'])) {
+					$pem = (string)file_get_contents($_FILES['ca_file']['tmp_name']);
+				} elseif (!empty($_POST['ca_pem'])) {
+					$pem = (string)$_POST['ca_pem'];
+				}
+				$res = $this->installSystemCA($pem, $_POST['ca_name'] ?? '');
+				if (!empty($res['status'])) {
+					$msg = $res['message'];
+					if (!empty($res['warning'])) { $msg .= ' ' . $res['warning']; }
+					$this->message = array('type' => 'success', 'message' => $msg);
+				} else {
+					$this->message = array('type' => 'danger', 'message' => $res['message']);
+				}
+			break;
 			case "importlocally":
 				$processed = $this->importLocalCertificates();
 				if(!empty($processed)) {
@@ -203,6 +219,9 @@ class Certman implements BMO {
 						}
 						$removeDstRootCaX3 = ($_POST['removeDstRootCaX3'] ? true : false);
 
+						$acmeUrl = !empty($_POST['acme_url']) ? trim($_POST['acme_url']) : '';
+						$acmeCaBundle = !empty($_POST['acme_ca']) ? trim($_POST['acme_ca']) : '';
+						$acmeInsecure = (!empty($_POST['acme_insecure'])) ? true : false;
 						if(!empty($cert)) {
 							$additional = array(
 								"C" => $_POST['C'],
@@ -211,6 +230,11 @@ class Certman implements BMO {
 								"removeDstRootCaX3" => $removeDstRootCaX3,
 							);
 							if (!empty($san)) {$additional['san'] = $san;}
+							if ($acmeUrl !== '') {
+								$additional['acmeUrl'] = $acmeUrl;
+								$additional['acmeCaBundle'] = $acmeCaBundle;
+								$additional['acmeInsecure'] = $acmeInsecure;
+							}
 							$removeDstRootCaX3 = ($_POST['removeDstRootCaX3'] ? true : false);
 							// check cert expiration
 							$cert = $this->getCertificateDetails($_POST['cid']);
@@ -232,7 +256,10 @@ class Certman implements BMO {
 									"challengetype" => "http", // https will not work.
 									"email" => $_POST['email'],
 									"san" => $san,
-									"removeDstRootCaX3" => $removeDstRootCaX3
+									"removeDstRootCaX3" => $removeDstRootCaX3,
+									"acmeUrl" => $acmeUrl,
+									"acmeCaBundle" => $acmeCaBundle,
+									"acmeInsecure" => $acmeInsecure
 								), false, true);
 							} catch(Exception $e) {
 								$lelog = trim(ob_get_contents());
@@ -292,6 +319,9 @@ class Certman implements BMO {
 							$description .= ", " . implode(", ", $san);
 						}
 						$removeDstRootCaX3 = ($_POST['removeDstRootCaX3'] ? true : false);
+						$acmeUrl = !empty($_POST['acme_url']) ? trim($_POST['acme_url']) : '';
+						$acmeCaBundle = !empty($_POST['acme_ca']) ? trim($_POST['acme_ca']) : '';
+						$acmeInsecure = (!empty($_POST['acme_insecure'])) ? true : false;
 						$additional = array(
 								"C" => $_POST['C'],
 								"ST" => $_POST['ST'],
@@ -299,6 +329,11 @@ class Certman implements BMO {
 								"removeDstRootCaX3" => $removeDstRootCaX3,
 						);
 						if (!empty($san)) {$additional['san'] = $san;}
+						if ($acmeUrl !== '') {
+							$additional['acmeUrl'] = $acmeUrl;
+							$additional['acmeCaBundle'] = $acmeCaBundle;
+							$additional['acmeInsecure'] = $acmeInsecure;
+						}
 						ob_start();
 						try{
 							if($this->checkCertificateName($host)) {
@@ -311,6 +346,9 @@ class Certman implements BMO {
 								"email" => $_POST['email'],
 								"san" => $san,
 								"removeDstRootCaX3" => $removeDstRootCaX3,
+								"acmeUrl" => $acmeUrl,
+								"acmeCaBundle" => $acmeCaBundle,
+								"acmeInsecure" => $acmeInsecure,
 							));
 							$this->saveCertificate(null, $host, $description, 'le', $additional);
 						} catch(Exception $e) {
@@ -538,6 +576,10 @@ class Certman implements BMO {
 					}
 				}
 			break;
+			case 'systemcas':
+				$systemcas = $this->getSystemCAs();
+				echo load_view(__DIR__.'/views/systemcas.php',array('systemcas' => $systemcas, 'message' => $this->message));
+			break;
 			default:
 				$certs = $this->getAllManagedCertificates();
 				$csr = $this->checkCSRexists();
@@ -621,6 +663,9 @@ class Certman implements BMO {
 							"email" => $cert['additional']['email'],
 							"san" => $cert['additional']['san'],
 							"removeDstRootCaX3" => $cert['additional']['removeDstRootCaX3'],
+							"acmeUrl" => $cert['additional']['acmeUrl'] ?? '',
+							"acmeCaBundle" => $cert['additional']['acmeCaBundle'] ?? '',
+							"acmeInsecure" => $cert['additional']['acmeInsecure'] ?? false,
 						);
 
 						$this->updateLE($cert['info']['crt']['subject']['CN'], $settings, false, $force);
@@ -664,6 +709,9 @@ class Certman implements BMO {
 							"email" => $cert['additional']['email'],
 							"san" => $cert['additional']['san'],
 							"removeDstRootCaX3" => $cert['additional']['removeDstRootCaX3'],
+							"acmeUrl" => $cert['additional']['acmeUrl'] ?? '',
+							"acmeCaBundle" => $cert['additional']['acmeCaBundle'] ?? '',
+							"acmeInsecure" => $cert['additional']['acmeInsecure'] ?? false,
 						);
 
 						$this->updateLE($cert['info']['crt']['subject']['CN'], $settings, false, $force);
@@ -737,6 +785,217 @@ class Certman implements BMO {
 	}
 
 	/**
+	 * Render an openssl DN array (subject/issuer) as a readable string.
+	 * @param array $dn
+	 * @return string
+	 */
+	private function dnToString($dn) {
+		$parts = array();
+		foreach ((array)$dn as $k => $v) {
+			if (is_array($v)) { $v = implode('+', $v); }
+			$parts[] = $k . '=' . $v;
+		}
+		return implode(', ', $parts);
+	}
+
+	/**
+	 * Detect which distribution trust-store family this server uses.
+	 * @return string 'debian', 'rhel', or '' when it can't be determined
+	 */
+	private function detectTrustStoreFamily() {
+		if (is_file('/etc/redhat-release')) { return 'rhel'; }
+		if (is_file('/etc/debian_version')) { return 'debian'; }
+		// Fall back to the presence of the trust tooling / anchor directories.
+		$hasRhel   = is_dir('/etc/pki/ca-trust/source/anchors') || (function_exists('fpbx_which') && fpbx_which('update-ca-trust'));
+		$hasDebian = is_dir('/usr/local/share/ca-certificates') || (function_exists('fpbx_which') && fpbx_which('update-ca-certificates'));
+		if ($hasRhel && !$hasDebian) { return 'rhel'; }
+		if ($hasDebian && !$hasRhel) { return 'debian'; }
+		return ''; // unknown or ambiguous - show everything
+	}
+
+	/**
+	 * Enumerate the CA certificates trusted by this server.
+	 *
+	 * Reads the active system CA bundle (the one PHP/cURL resolve to) plus the
+	 * common distribution bundle files and custom trust-anchor directories, then
+	 * returns the parsed certificates. This is primarily a helper for operators
+	 * configuring a private/self-hosted ACME server: it lets them confirm the
+	 * ACME server's CA is already trusted and locate a CA bundle path to use in
+	 * the "ACME Server CA Bundle" field.
+	 *
+	 * @return array array('sources' => array(...), 'cas' => array(...))
+	 */
+	public function getSystemCAs() {
+		$candidates = array();
+
+		// Whatever PHP/cURL currently resolve to (file or directory).
+		$primary = $this->getCABundle();
+		if (!empty($primary)) {
+			$candidates[$primary] = _('Active system CA bundle (used by PHP/cURL)');
+		}
+
+		// Common distribution bundle files and custom anchor directories, each
+		// tagged with the distro family it belongs to ('any' = generic).
+		$known = array(
+			'/etc/ssl/certs/ca-certificates.crt' => array('label' => _('Debian/Ubuntu system bundle'),        'family' => 'debian'),
+			'/etc/pki/tls/certs/ca-bundle.crt'   => array('label' => _('RHEL/CentOS system bundle'),          'family' => 'rhel'),
+			'/etc/ssl/cert.pem'                  => array('label' => _('OpenSSL default bundle'),              'family' => 'any'),
+			'/usr/local/share/ca-certificates'   => array('label' => _('Custom CAs (Debian/Ubuntu anchors)'), 'family' => 'debian'),
+			'/etc/pki/ca-trust/source/anchors'   => array('label' => _('Custom CAs (RHEL/CentOS anchors)'),   'family' => 'rhel'),
+		);
+		// Only list stores that match the detected distro; show everything when unknown.
+		$family = $this->detectTrustStoreFamily();
+		foreach ($known as $path => $meta) {
+			if (isset($candidates[$path])) { continue; }
+			if ($family !== '' && $meta['family'] !== 'any' && $meta['family'] !== $family) { continue; }
+			$candidates[$path] = $meta['label'];
+		}
+
+		$sources = array();
+		$cas = array();
+		$seen = array(); // dedupe identical certs that appear in several stores
+
+		foreach ($candidates as $path => $label) {
+			$files = array();
+			if (is_dir($path)) {
+				foreach ((array)glob(rtrim($path, '/') . '/*') as $f) {
+					if (is_file($f)) { $files[] = $f; }
+				}
+			} elseif (is_file($path)) {
+				$files[] = $path;
+			} else {
+				$sources[] = array('path' => $path, 'label' => $label, 'exists' => false, 'count' => 0);
+				continue;
+			}
+
+			$count = 0;
+			foreach ($files as $f) {
+				$contents = @file_get_contents($f);
+				if ($contents === false) { continue; }
+				foreach ($this->parseCaBundle($contents) as $pem) {
+					if (strpos($pem, 'BEGIN CERTIFICATE') === false) { continue; }
+					$info = @openssl_x509_parse($pem);
+					if (empty($info)) { continue; }
+					$fp = @openssl_x509_fingerprint($pem, 'sha1');
+					if ($fp && isset($seen[$fp])) { continue; }
+					if ($fp) { $seen[$fp] = true; }
+					$count++;
+					$subject = $info['subject'] ?? array();
+					$issuer  = $info['issuer'] ?? array();
+					$cas[] = array(
+						'cn'               => $subject['CN'] ?? ($subject['O'] ?? ($subject['OU'] ?? _('(unnamed)'))),
+						'subject'          => $this->dnToString($subject),
+						'issuer'           => $this->dnToString($issuer),
+						'validFrom_time_t' => $info['validFrom_time_t'] ?? 0,
+						'validTo_time_t'   => $info['validTo_time_t'] ?? 0,
+						'selfSigned'       => ($subject == $issuer),
+						'fingerprint'      => $fp ? strtoupper(implode(':', str_split($fp, 2))) : '',
+						'source'           => $f,
+					);
+				}
+			}
+			$sources[] = array('path' => $path, 'label' => $label, 'exists' => true, 'count' => $count);
+		}
+
+		usort($cas, function ($a, $b) { return strcasecmp($a['cn'], $b['cn']); });
+
+		return array('sources' => $sources, 'cas' => $cas);
+	}
+
+	/**
+	 * Install a CA certificate into the system trust store.
+	 *
+	 * Validates the supplied PEM, stages it in the module's ca-staging directory
+	 * and triggers the privileged "install-ca" hook (run as root by the Sysadmin
+	 * incron runner) which copies it into the distribution trust anchors and
+	 * refreshes the trust store. When already running as root (e.g. fwconsole)
+	 * the hook is executed directly. Installation is confirmed by re-scanning the
+	 * trust store for the certificate fingerprint.
+	 *
+	 * @param  string $pem          PEM encoded CA certificate
+	 * @param  string $friendlyName Optional friendly name used for the stored filename
+	 * @return array  array('status' => bool, 'message' => string[, 'warning' => string])
+	 */
+	public function installSystemCA($pem, $friendlyName = '') {
+		$pem = trim((string)$pem);
+		if ($pem === '') {
+			return array('status' => false, 'message' => _('No certificate data provided'));
+		}
+
+		$info = @openssl_x509_parse($pem);
+		if (empty($info)) {
+			return array('status' => false, 'message' => _('The supplied data is not a valid PEM certificate'));
+		}
+		$fp = @openssl_x509_fingerprint($pem, 'sha1');
+		$cn = $info['subject']['CN'] ?? ($info['subject']['O'] ?? 'ca');
+		// A trust anchor should be a CA; warn (but don't block) if it is not.
+		$isCa = !empty($info['extensions']['basicConstraints']) && stripos($info['extensions']['basicConstraints'], 'CA:TRUE') !== false;
+
+		// Build a safe target basename.
+		$name = $friendlyName !== '' ? $friendlyName : $cn;
+		$name = preg_replace('/[^A-Za-z0-9._-]+/', '_', (string)$name);
+		$name = trim($name, '._-');
+		if ($name === '') { $name = 'ca'; }
+		$base = 'certman-' . $name;
+
+		// Stage the PEM where the root hook can read it.
+		$staging = __DIR__ . '/ca-staging';
+		if (!is_dir($staging) && !@mkdir($staging, 0775, true)) {
+			return array('status' => false, 'message' => sprintf(_('Unable to create staging directory %s'), $staging));
+		}
+		$crtFile = $staging . '/' . $base . '.crt';
+		$resultFile = $staging . '/' . $base . '.result';
+		@unlink($resultFile);
+		if (@file_put_contents($crtFile, $pem . "\n") === false) {
+			return array('status' => false, 'message' => _('Unable to stage the certificate for installation'));
+		}
+
+		// Run the privileged install.
+		try {
+			if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+				// Already root (e.g. fwconsole) - run the hook directly.
+				exec(escapeshellarg(__DIR__ . '/hooks/install-ca') . ' 2>&1');
+			} else {
+				$this->runHook('install-ca');
+				// incron is asynchronous; wait for the hook to drop its result file.
+				$waited = 0;
+				while (!file_exists($resultFile) && $waited < 20) {
+					usleep(500000);
+					$waited++;
+				}
+			}
+		} catch (\Exception $e) {
+			@unlink($crtFile);
+			return array('status' => false, 'message' => sprintf(_('Unable to run the privileged install hook: %s. The Sysadmin module is required to install CAs into the system trust store from the web interface.'), $e->getMessage()));
+		}
+
+		$hookResult = file_exists($resultFile) ? trim((string)@file_get_contents($resultFile)) : '';
+		@unlink($resultFile);
+		@unlink($crtFile); // the hook removes it on success; clean up just in case
+
+		// Confirm the certificate is now present in the trust store.
+		$installed = false;
+		if ($fp) {
+			$target = strtoupper(implode(':', str_split($fp, 2)));
+			$sys = $this->getSystemCAs();
+			foreach ($sys['cas'] as $c) {
+				if (!empty($c['fingerprint']) && $c['fingerprint'] === $target) { $installed = true; break; }
+			}
+		}
+
+		if ($installed) {
+			$result = array('status' => true, 'message' => sprintf(_('CA "%s" was installed into the system trust store.'), $cn));
+			if (!$isCa) {
+				$result['warning'] = _('Note: this certificate is not marked as a CA (basicConstraints CA:TRUE).');
+			}
+			return $result;
+		}
+
+		$detail = $hookResult !== '' ? $hookResult : _('the certificate was staged but could not be confirmed in the system trust store. Ensure the Sysadmin module is installed and up to date.');
+		return array('status' => false, 'message' => sprintf(_('Could not confirm installation of CA "%s": %s'), $cn, $detail));
+	}
+
+	/**
 	 * Parse CA bundle into an array
 	 * @param string $contents the contents of the bundle
 	 * 
@@ -801,6 +1060,12 @@ class Certman implements BMO {
 		$email = !empty($settings['email']) ? $settings['email'] : '';
 		$san = !empty($settings['san']) ? $settings['san'] : array();
 		$removeDstRootCaX3 = !empty($settings['removeDstRootCaX3']) ? $settings['removeDstRootCaX3'] : false;
+		// Custom / private ACME server (self-hosted Let's Encrypt compatible, http-01).
+		// When acmeUrl is set we point lescript at it instead of the public LE endpoint.
+		$acmeUrl = !empty($settings['acmeUrl']) ? trim($settings['acmeUrl']) : '';
+		$acmeCaBundle = !empty($settings['acmeCaBundle']) ? trim($settings['acmeCaBundle']) : '';
+		$acmeInsecure = !empty($settings['acmeInsecure']) ? true : false;
+		$useCustomAcme = ($acmeUrl !== '');
 
 		$location = $this->PKCS->getKeysLocation();
 		$logger = $this->FreePBX->Logger->monoLog;
@@ -879,23 +1144,27 @@ class Certman implements BMO {
 
 			//Now check freepbx.org
 			//	on failure, save error as hint and continue
-				try {
-					$pest = new \PestJSON('http://mirror1.freepbx.org');
-					$pest->curl_opts[CURLOPT_FOLLOWLOCATION] = true;
-					$pest->curl_opts[CURLOPT_CONNECTTIMEOUT] = 10;
-					$pest->curl_opts[CURLOPT_TIMEOUT] = 30;
-					$thing = $pest->get('/lechecker.php', array('host' => $host, 'path' => $pathCheck, 'token' => $token, 'type' => $challengetype));
-					if(empty($thing)) {
-						$lecheckerr = _("No valid response from http://mirror1.freepbx.org");
-					} elseif(!$thing['status']) {
-						$lecheckerr = $thing['message'];
+			//	Skipped for a custom/private ACME server: that public reachability
+			//	probe is only meaningful for the public Let's Encrypt service.
+				if(!$useCustomAcme) {
+					try {
+						$pest = new \PestJSON('http://mirror1.freepbx.org');
+						$pest->curl_opts[CURLOPT_FOLLOWLOCATION] = true;
+						$pest->curl_opts[CURLOPT_CONNECTTIMEOUT] = 10;
+						$pest->curl_opts[CURLOPT_TIMEOUT] = 30;
+						$thing = $pest->get('/lechecker.php', array('host' => $host, 'path' => $pathCheck, 'token' => $token, 'type' => $challengetype));
+						if(empty($thing)) {
+							$lecheckerr = _("No valid response from http://mirror1.freepbx.org");
+						} elseif(!$thing['status']) {
+							$lecheckerr = $thing['message'];
+						}
+					} catch(Exception $e) {
+						$lecheckerr =  _("lechecker: ") . get_class($e) . " - " . trim(strip_tags($e->getMessage()));
 					}
-				} catch(Exception $e) {
-					$lecheckerr =  _("lechecker: ") . get_class($e) . " - " . trim(strip_tags($e->getMessage()));
-				}
-				if ($lecheckerr) {
-					print($lecheckerr . "\n");
-					$hints[] = $lecheckerr;
+					if ($lecheckerr) {
+						print($lecheckerr . "\n");
+						$hints[] = $lecheckerr;
+					}
 				}
 				@unlink($webroot.$pathCheck);
 			}
@@ -904,9 +1173,25 @@ class Certman implements BMO {
 			if($needsgen) {
 				$tokenpath = $webroot . "/.well-known/acme-challenge";
 				$prechallengefiles = glob($tokenpath .'/*'); // */
-				$le = new \Analogic\ACME\Lescript($location, $webroot, $logger);
-				if($staging) {
-					$le->ca = 'https://acme-staging.api.letsencrypt.org';
+				if($useCustomAcme) {
+					// Private ACME server: inject our own transport so lescript talks
+					// to the configured directory URL (and trusts a private CA if set).
+					require_once __DIR__ . '/Acme/AcmeHttpClient.php';
+					$origin = preg_replace('~^(https?://[^/]+).*~', '$1', $acmeUrl);
+					$client = new \FreePBX\modules\Certman\AcmeHttpClient(
+						$origin,
+						$acmeUrl,
+						($acmeCaBundle !== '' ? $acmeCaBundle : null),
+						$acmeInsecure
+					);
+					$le = new \Analogic\ACME\Lescript($location, $webroot, $logger, $client);
+					$le->ca = $acmeUrl;
+					print(sprintf(_("Using custom ACME server: %s\n"), $acmeUrl));
+				} else {
+					$le = new \Analogic\ACME\Lescript($location, $webroot, $logger);
+					if($staging) {
+						$le->ca = 'https://acme-staging.api.letsencrypt.org';
+					}
 				}
 				$le->countryCode = $countryCode;
 				$le->state = $state;

--- a/Certman.class.php
+++ b/Certman.class.php
@@ -921,31 +921,51 @@ class Certman implements BMO {
 		if ($pem === '') {
 			return array('status' => false, 'message' => _('No certificate data provided'));
 		}
+		if (strlen($pem) > 100000) {
+			return array('status' => false, 'message' => _('The supplied certificate data is too large.'));
+		}
+		// Never accept a private key here - we only install public CA certificates.
+		if (stripos($pem, 'PRIVATE KEY') !== false) {
+			return array('status' => false, 'message' => _('The supplied data contains a private key; provide only the CA certificate.'));
+		}
+		// Exactly one certificate, so the operator sees precisely what is trusted
+		// and we never trust extra certificates hidden in a bundle.
+		if (substr_count($pem, '-----BEGIN CERTIFICATE-----') !== 1) {
+			return array('status' => false, 'message' => _('Please provide exactly one CA certificate in PEM format.'));
+		}
 
 		$info = @openssl_x509_parse($pem);
 		if (empty($info)) {
 			return array('status' => false, 'message' => _('The supplied data is not a valid PEM certificate'));
 		}
 		$fp = @openssl_x509_fingerprint($pem, 'sha1');
-		$cn = $info['subject']['CN'] ?? ($info['subject']['O'] ?? 'ca');
+		$rawCn = $info['subject']['CN'] ?? ($info['subject']['O'] ?? 'ca');
+		// The CN comes from an attacker-controlled certificate and is rendered as
+		// HTML in the web message, so escape it for display.
+		$cn = htmlspecialchars((string)$rawCn, ENT_QUOTES);
 		// A trust anchor should be a CA; warn (but don't block) if it is not.
 		$isCa = !empty($info['extensions']['basicConstraints']) && stripos($info['extensions']['basicConstraints'], 'CA:TRUE') !== false;
 
-		// Build a safe target basename.
-		$name = $friendlyName !== '' ? $friendlyName : $cn;
+		// Build a safe, collision-resistant target basename (name + fingerprint).
+		$name = $friendlyName !== '' ? $friendlyName : $rawCn;
 		$name = preg_replace('/[^A-Za-z0-9._-]+/', '_', (string)$name);
 		$name = trim($name, '._-');
 		if ($name === '') { $name = 'ca'; }
-		$base = 'certman-' . $name;
+		$fpShort = $fp ? substr(preg_replace('/[^a-f0-9]/i', '', $fp), 0, 12) : '';
+		$base = 'certman-' . $name . ($fpShort !== '' ? '-' . $fpShort : '');
 
 		// Stage the PEM where the root hook can read it.
 		$staging = __DIR__ . '/ca-staging';
 		if (!is_dir($staging) && !@mkdir($staging, 0775, true)) {
 			return array('status' => false, 'message' => sprintf(_('Unable to create staging directory %s'), $staging));
 		}
+		// Clean slate: drop any leftover staged files so the root hook only ever
+		// processes the certificate we are about to write.
+		foreach ((array)glob($staging . '/*.{crt,result}', GLOB_BRACE) as $stale) {
+			@unlink($stale);
+		}
 		$crtFile = $staging . '/' . $base . '.crt';
 		$resultFile = $staging . '/' . $base . '.result';
-		@unlink($resultFile);
 		if (@file_put_contents($crtFile, $pem . "\n") === false) {
 			return array('status' => false, 'message' => _('Unable to stage the certificate for installation'));
 		}
@@ -953,8 +973,8 @@ class Certman implements BMO {
 		// Run the privileged install.
 		try {
 			if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
-				// Already root (e.g. fwconsole) - run the hook directly.
-				exec(escapeshellarg(__DIR__ . '/hooks/install-ca') . ' 2>&1');
+				// Already root (e.g. fwconsole) - run the hook directly, restricted to our file.
+				exec(escapeshellarg(__DIR__ . '/hooks/install-ca') . ' ' . escapeshellarg($base . '.crt') . ' 2>&1');
 			} else {
 				$this->runHook('install-ca');
 				// incron is asynchronous; wait for the hook to drop its result file.
@@ -973,9 +993,14 @@ class Certman implements BMO {
 		@unlink($resultFile);
 		@unlink($crtFile); // the hook removes it on success; clean up just in case
 
-		// Confirm the certificate is now present in the trust store.
-		$installed = false;
-		if ($fp) {
+		// The hook is authoritative: it reports "OK" only after update-ca-* actually
+		// succeeded (and rolls the anchor back otherwise).
+		$hookOk = ($hookResult !== '' && stripos($hookResult, 'OK') === 0);
+
+		// Only when the hook left no result (e.g. it ran fully out-of-band) do we
+		// fall back to confirming the certificate is present in the trust store.
+		$installed = $hookOk;
+		if (!$installed && $hookResult === '' && $fp) {
 			$target = strtoupper(implode(':', str_split($fp, 2)));
 			$sys = $this->getSystemCAs();
 			foreach ($sys['cas'] as $c) {
@@ -991,7 +1016,7 @@ class Certman implements BMO {
 			return $result;
 		}
 
-		$detail = $hookResult !== '' ? $hookResult : _('the certificate was staged but could not be confirmed in the system trust store. Ensure the Sysadmin module is installed and up to date.');
+		$detail = $hookResult !== '' ? htmlspecialchars($hookResult, ENT_QUOTES) : _('the certificate was staged but could not be confirmed in the system trust store. Ensure the Sysadmin module is installed and up to date.');
 		return array('status' => false, 'message' => sprintf(_('Could not confirm installation of CA "%s": %s'), $cn, $detail));
 	}
 

--- a/Console/Certman.class.php
+++ b/Console/Certman.class.php
@@ -30,6 +30,7 @@ class Certman extends Command {
 				new InputOption('updateall', null, InputOption::VALUE_NONE, _('Check and Update all Certificates')),
 				new InputOption('force', null, InputOption::VALUE_NONE, _('Force update, by pass 30 days expiry ')),
 				new InputOption('import', null, InputOption::VALUE_NONE, sprintf(_('Import any unmanaged certificates in %s'),$loc)),
+				new InputOption('install-ca', null, InputOption::VALUE_REQUIRED, _('Install a CA certificate (path to a PEM file) into the system trust store')),
 
 				// cert generation options
 				new InputOption('generate', null, InputOption::VALUE_NONE, _('Generate Certificate')),
@@ -39,6 +40,9 @@ class Certman extends Command {
 				new InputOption('state', null, InputOption::VALUE_REQUIRED, _('State/Provence/Region (LetsEncrypt Generation)')),
 				new InputOption('email', null, InputOption::VALUE_REQUIRED, _("Owner's email (LetsEncrypt Generation)")),
 				new InputOption('san', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, _("Certificate Subject Alternative Name(s) (LetsEncrypt Generation)")),
+				new InputOption('acme-url', null, InputOption::VALUE_REQUIRED, _('Custom ACME directory URL for a private/self-hosted Let\'s Encrypt server (LetsEncrypt Generation). Empty uses the public service')),
+				new InputOption('acme-ca', null, InputOption::VALUE_REQUIRED, _('Path to the CA bundle that signed the custom ACME server certificate (LetsEncrypt Generation)')),
+				new InputOption('acme-insecure', null, InputOption::VALUE_NONE, _('Skip TLS verification of the custom ACME server (LetsEncrypt Generation)')),
 
 				new InputOption('delete', null, InputOption::VALUE_REQUIRED, _('Delete certificate by id or hostname')),
 				new InputOption('default', null, InputOption::VALUE_REQUIRED, _('Set default certificate by id or hostname')),
@@ -49,6 +53,23 @@ class Certman extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output){
 		$certman = \FreePBX::create()->Certman;
 		$pkcs = \FreePBX::create()->PKCS;
+
+		if($installCa = $input->getOption('install-ca')) {
+			if(!is_file($installCa)) {
+				$output->writeln("<error>".sprintf(_("File not found: %s"), $installCa)."</error>");
+				exit(4);
+			}
+			$pem = file_get_contents($installCa);
+			$res = $certman->installSystemCA($pem, basename($installCa));
+			if(!empty($res['status'])) {
+				$msg = $res['message'];
+				if(!empty($res['warning'])) { $msg .= ' ' . $res['warning']; }
+				$output->writeln("<info>".$msg."</info>");
+				return 0;
+			}
+			$output->writeln("<error>".$res['message']."</error>");
+			exit(4);
+		}
 
 		if($input->getOption('generate')) {
 			$type = $input->getOption('type');
@@ -66,6 +87,9 @@ class Certman extends Command {
 					$description = $hostname;
 					$san = array_unique(array_filter(array_map(function ($v) {return strtolower(trim($v));}, $input->getOption('san'))));
 					$force = $input->getOption('force');
+					$acmeUrl = trim((string)$input->getOption('acme-url'));
+					$acmeCaBundle = trim((string)$input->getOption('acme-ca'));
+					$acmeInsecure = (bool)$input->getOption('acme-insecure');
 					$cert = $certman->getCertificateDetailsByBasename($hostname);
 
 					if (!($hostname && $country_code && $state && $email)) {
@@ -88,6 +112,11 @@ class Certman extends Command {
 						"removeDstRootCaX3" => false,
 					);
 					if (!empty($san)) {$additional['san'] = $san;}
+					if ($acmeUrl !== '') {
+						$additional['acmeUrl'] = $acmeUrl;
+						$additional['acmeCaBundle'] = $acmeCaBundle;
+						$additional['acmeInsecure'] = $acmeInsecure;
+					}
 
 					if ($force) {
 						$output->writeln("<info>" . _("Forced update enabled !!!") . "</info>");
@@ -110,6 +139,9 @@ class Certman extends Command {
 							"email" => $email,
 							"san" => $san,
 							"removeDstRootCaX3" => false,
+							"acmeUrl" => $acmeUrl,
+							"acmeCaBundle" => $acmeCaBundle,
+							"acmeInsecure" => $acmeInsecure,
 						);
 
 						$le_result = $certman->updateLE($hostname, $settings, false, $force);

--- a/assets/js/certman.js
+++ b/assets/js/certman.js
@@ -112,7 +112,7 @@ $(function() {
 		var stop = false,
 				type = $("#certtype").val();
 		$("form[name=frm_certman] input[type=\"text\"]").each( function(i, v) {
-			if($(this).attr("name") == "ST" || $(this).attr("name") == "L" || $(this).attr("name") == "OU") {
+			if($(this).attr("name") == "ST" || $(this).attr("name") == "L" || $(this).attr("name") == "OU" || $(this).attr("name") == "acme_url" || $(this).attr("name") == "acme_ca") {
 				return true;
 			}
 			if ($(this).val() === "") {

--- a/hooks/install-ca
+++ b/hooks/install-ca
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Certificate Manager - install CA certificate(s) into the system trust store.
+#
+# This hook is executed AS ROOT by the Sysadmin incron runner (see runHook()).
+# The web UI, running as the unprivileged web user, stages one or more PEM
+# certificates as *.crt files in the module's ca-staging directory; this hook
+# copies each into the distribution trust anchors and refreshes the trust store.
+# For every staged file it writes a <name>.result file the web side reads back,
+# then removes the staged input.
+
+MODDIR="$(cd "$(dirname "$0")/.." && pwd)"
+STAGING="$MODDIR/ca-staging"
+
+[ -d "$STAGING" ] || exit 0
+
+# Pick the distribution trust mechanism.
+if command -v update-ca-trust >/dev/null 2>&1 && [ -d /etc/pki/ca-trust/source/anchors ]; then
+	DEST="/etc/pki/ca-trust/source/anchors"
+	MODE="rhel"
+elif command -v update-ca-certificates >/dev/null 2>&1 && [ -d /usr/local/share/ca-certificates ]; then
+	DEST="/usr/local/share/ca-certificates"
+	MODE="debian"
+else
+	MODE="none"
+fi
+
+shopt -s nullglob
+for f in "$STAGING"/*.crt; do
+	base="$(basename "${f%.crt}")"
+	result="${f%.crt}.result"
+
+	if [ "$MODE" = "none" ]; then
+		echo "ERROR: no supported system trust store found (need update-ca-trust or update-ca-certificates)" > "$result"
+		rm -f "$f"
+		continue
+	fi
+
+	# Make sure it really is a certificate before trusting it.
+	if ! openssl x509 -in "$f" -noout >/dev/null 2>&1; then
+		echo "ERROR: not a valid PEM certificate" > "$result"
+		rm -f "$f"
+		continue
+	fi
+
+	if cp "$f" "$DEST/$base.crt" 2>/dev/null; then
+		chmod 0644 "$DEST/$base.crt"
+		if [ "$MODE" = "rhel" ]; then
+			update-ca-trust extract >/dev/null 2>&1
+		else
+			update-ca-certificates >/dev/null 2>&1
+		fi
+		echo "OK: installed as $DEST/$base.crt" > "$result"
+	else
+		echo "ERROR: could not write to $DEST" > "$result"
+	fi
+	rm -f "$f"
+done
+
+exit 0

--- a/hooks/install-ca
+++ b/hooks/install-ca
@@ -2,14 +2,18 @@
 # Certificate Manager - install CA certificate(s) into the system trust store.
 #
 # This hook is executed AS ROOT by the Sysadmin incron runner (see runHook()).
-# The web UI, running as the unprivileged web user, stages one or more PEM
-# certificates as *.crt files in the module's ca-staging directory; this hook
-# copies each into the distribution trust anchors and refreshes the trust store.
-# For every staged file it writes a <name>.result file the web side reads back,
-# then removes the staged input.
+# The web UI, running as the unprivileged web user, stages a PEM certificate as a
+# *.crt file in the module's ca-staging directory; this hook copies it into the
+# distribution trust anchors and refreshes the trust store. For every staged file
+# it writes a <name>.result file the web side reads back, then removes the input.
+#
+# An optional argument restricts processing to a single staged file (basename
+# only); without it, the whole directory is processed but stale files (planted
+# and left behind) are ignored as a defence-in-depth measure.
 
 MODDIR="$(cd "$(dirname "$0")/.." && pwd)"
 STAGING="$MODDIR/ca-staging"
+TARGET="$1"
 
 [ -d "$STAGING" ] || exit 0
 
@@ -24,10 +28,27 @@ else
 	MODE="none"
 fi
 
-shopt -s nullglob
-for f in "$STAGING"/*.crt; do
+# Determine which staged files to process.
+if [ -n "$TARGET" ]; then
+	# basename() ensures the argument can never escape the staging directory.
+	files=("$STAGING/$(basename "$TARGET")")
+else
+	shopt -s nullglob
+	files=("$STAGING"/*.crt)
+fi
+
+for f in "${files[@]}"; do
+	[ -f "$f" ] || continue
+	[[ "$f" == *.crt ]] || continue
 	base="$(basename "${f%.crt}")"
 	result="${f%.crt}.result"
+
+	# Defence in depth: when processing the whole directory, ignore (and remove)
+	# stale staged files older than 5 minutes that may have been planted.
+	if [ -z "$TARGET" ] && [ -n "$(find "$f" -mmin +5 2>/dev/null)" ]; then
+		rm -f "$f"
+		continue
+	fi
 
 	if [ "$MODE" = "none" ]; then
 		echo "ERROR: no supported system trust store found (need update-ca-trust or update-ca-certificates)" > "$result"
@@ -49,7 +70,14 @@ for f in "$STAGING"/*.crt; do
 		else
 			update-ca-certificates >/dev/null 2>&1
 		fi
-		echo "OK: installed as $DEST/$base.crt" > "$result"
+		rc=$?
+		if [ "$rc" -eq 0 ]; then
+			echo "OK: installed as $DEST/$base.crt" > "$result"
+		else
+			# Roll back so we never leave an anchor that the trust store didn't accept.
+			rm -f "$DEST/$base.crt"
+			echo "ERROR: trust store update failed (exit $rc)" > "$result"
+		fi
 	else
 		echo "ERROR: could not write to $DEST" > "$result"
 	fi

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 	<rawname>certman</rawname>
 	<name>Certificate Manager</name>
 	<repo>standard</repo>
-	<version>16.0.30</version>
+	<version>16.0.31</version>
 	<publisher>Sangoma Technologies Corporation</publisher>
 	<license>AGPLv3+</license>
 	<licenselink>http://www.gnu.org/licenses/agpl-3.0.txt</licenselink>
@@ -14,6 +14,7 @@
 	</description>
 	<more-info>https://wiki.freepbx.org/display/FPG/Certificate+Management+Module</more-info>
 	<changelog>
+		*16.0.31* feat: Add private ACME server support, installed-CA viewer and web/CLI option to install a CA certificate into the system trust store (via privileged sysadmin hook).
 		*16.0.30* Packaging of ver 16.0.30
 		*16.0.29* FREEI-114 certificate update notification change in dashboard 
 		*16.0.28* FREEPBX-24228 

--- a/views/certgrid.php
+++ b/views/certgrid.php
@@ -20,6 +20,7 @@
 		<a href="?display=certman&amp;certaction=delete&amp;type=ca" class="btn btn-danger" id="delCA"><i class="fa fa-times"></i> <?php echo _("Delete Self-Signed CA")?></a>
 	<?php } ?>
 	<a href="?display=certman&amp;certaction=importlocally" class="btn btn-primary"><?php echo _("Import Locally")?></a>
+	<a href="?display=certman&amp;action=systemcas" class="btn btn-default"><i class="fa fa-certificate"></i> <?php echo _("Installed CAs")?></a>
 </div>
 <table data-toolbar="#toolbar-all" data-maintain-selected="true" data-show-columns="true" data-show-toggle="true" data-toggle="table" data-pagination="true" data-search="true" class="table table-striped">
 	<thead>

--- a/views/le.php
+++ b/views/le.php
@@ -139,6 +139,64 @@ $alert .= "</div>";
 								</div>
 								<!-- END Challenge Method -->
 
+								<!-- Custom / Private ACME server -->
+								<?php
+									$acmeUrl = $cert['additional']['acmeUrl'] ?? '';
+									$acmeCa  = $cert['additional']['acmeCaBundle'] ?? '';
+									$acmeInsecure = !empty($cert['additional']['acmeInsecure']);
+								?>
+								<div class="element-container">
+									<div class="row">
+										<div class="form-group form-horizontal">
+											<div class="col-md-3">
+												<label class="control-label" for="acme_url"><?php echo _("Custom ACME Server URL")?></label>
+												<i class="fa fa-question-circle fpbx-help-icon" data-for="acme_url"></i>
+											</div>
+											<div class="col-md-9">
+												<input type="text" class="form-control" id="acme_url" name="acme_url" placeholder="https://acme.internal.example.com/acme/acme/directory" value="<?php echo htmlspecialchars($acmeUrl, ENT_QUOTES); ?>">
+											</div>
+										</div>
+										<div class="col-md-12">
+											<span id="acme_url-help" class="help-block fpbx-help-block"><?php echo _("Leave empty to use the public Let's Encrypt service. To use a private/self-hosted ACME server, enter the full ACME <strong>directory</strong> URL (e.g. step-ca: <code>/acme/&lt;provisioner&gt;/directory</code>, Pebble: <code>/dir</code>). Validation still uses the http-01 challenge on port 80.")?></span>
+										</div>
+									</div>
+								</div>
+
+								<div class="element-container">
+									<div class="row">
+										<div class="form-group form-horizontal">
+											<div class="col-md-3">
+												<label class="control-label" for="acme_ca"><?php echo _("ACME Server CA Bundle")?></label>
+												<i class="fa fa-question-circle fpbx-help-icon" data-for="acme_ca"></i>
+											</div>
+											<div class="col-md-9">
+												<input type="text" class="form-control" id="acme_ca" name="acme_ca" placeholder="/etc/ssl/certs/internal-ca.pem" value="<?php echo htmlspecialchars($acmeCa, ENT_QUOTES); ?>">
+											</div>
+										</div>
+										<div class="col-md-12">
+											<span id="acme_ca-help" class="help-block fpbx-help-block"><?php echo _("Optional. Only needed when the custom ACME server presents a TLS certificate signed by a private CA that this server does not already trust. You have three options, pick one: (1) install that CA into the system trust store from the <strong>Installed CAs</strong> page and leave this field empty; (2) enter here the path to a PEM CA bundle that signs the ACME server certificate; or (3) enable <strong>Skip ACME Server TLS Verification</strong> below. Leave empty for the public Let's Encrypt service.")?></span>
+										</div>
+									</div>
+								</div>
+
+								<div class="element-container">
+									<div class="row">
+										<div class="form-group form-horizontal">
+											<div class="col-md-3">
+												<label class="control-label" for="acme_insecure"><?php echo _("Skip ACME Server TLS Verification")?></label>
+												<i class="fa fa-question-circle fpbx-help-icon" data-for="acme_insecure"></i>
+											</div>
+											<div class="col-md-9">
+												<input type="checkbox" id="acme_insecure" name="acme_insecure" <?php echo ($acmeInsecure ? "checked" : ""); ?>>
+											</div>
+										</div>
+										<div class="col-md-12">
+											<span id="acme_insecure-help" class="help-block fpbx-help-block"><?php echo _("Disable TLS certificate verification when connecting to the custom ACME server. Use only for self-signed servers on a trusted network when no CA bundle is available. Ignored for the public Let's Encrypt service.")?></span>
+										</div>
+									</div>
+								</div>
+								<!-- END Custom / Private ACME server -->
+
 								<!-- Remove DST Root CA X3 -->
 								<div class="element-container">
 									<div class="row">

--- a/views/systemcas.php
+++ b/views/systemcas.php
@@ -1,0 +1,150 @@
+<?php
+//	License for all code of this FreePBX module can be found in the license file inside the module directory
+$sources = $systemcas['sources'] ?? array();
+$cas = $systemcas['cas'] ?? array();
+$now = time();
+?>
+<div class="container-fluid">
+	<h1><?php echo _('Installed Certificate Authorities')?></h1>
+
+	<?php if(!empty($message) && !empty($message['message'])) { ?>
+		<div class="alert alert-<?php echo htmlspecialchars($message['type'] ?? 'info', ENT_QUOTES); ?> alert-dismissable">
+			<span class="fa fa-times close" data-dismiss="alert" aria-hidden="true"></span>
+			<?php echo $message['message']; ?>
+		</div>
+	<?php } ?>
+
+	<div class="alert alert-info">
+		<?php echo _("These are the CA certificates trusted by this server (the same trust store used by PHP/cURL for outbound TLS). Use this list to confirm that a private/self-hosted ACME server's CA is already trusted, and to find a CA bundle path for the \"ACME Server CA Bundle\" field when generating a Let's Encrypt certificate.")?>
+	</div>
+
+	<!-- Install a CA into the system trust store (collapsible) -->
+	<div class="panel panel-default">
+		<div class="panel-heading" style="cursor:pointer;" data-toggle="collapse" data-target="#install-ca-body" aria-expanded="false">
+			<div class="panel-title">
+				<i class="fa fa-upload"></i>&nbsp;<?php echo _("Install a CA Certificate")?>
+				<i class="fa fa-chevron-down pull-right"></i>
+			</div>
+		</div>
+		<div class="panel-body collapse" id="install-ca-body">
+		<div class="alert alert-warning">
+			<?php echo _("This installs the certificate into the operating system trust store, so it becomes trusted system-wide (cURL, PHP, etc.). Only install CA certificates you trust: a malicious CA can be used to intercept TLS traffic. This requires the Sysadmin module (the install runs as root).")?>
+		</div>
+		<form class="" name="frm_installca" action="config.php?display=certman&amp;action=systemcas" method="post" enctype="multipart/form-data">
+			<input type="hidden" name="certaction" value="installca">
+			<div class="element-container">
+				<div class="row">
+					<div class="form-group form-horizontal">
+						<div class="col-md-3"><label class="control-label" for="ca_name"><?php echo _("Friendly Name")?></label></div>
+						<div class="col-md-9">
+							<input type="text" class="form-control" id="ca_name" name="ca_name" placeholder="internal-acme-ca">
+							<span class="help-block fpbx-help-block"><?php echo _("Optional. Used for the stored filename (it will be prefixed with 'certman-'). Defaults to the certificate Common Name.")?></span>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="element-container">
+				<div class="row">
+					<div class="form-group form-horizontal">
+						<div class="col-md-3"><label class="control-label" for="ca_pem"><?php echo _("CA Certificate (PEM)")?></label></div>
+						<div class="col-md-9">
+							<textarea class="form-control" id="ca_pem" name="ca_pem" rows="8" placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"></textarea>
+							<span class="help-block fpbx-help-block"><?php echo _("Paste the PEM encoded CA certificate, or upload a file below. If both are provided, the uploaded file is used.")?></span>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="element-container">
+				<div class="row">
+					<div class="form-group form-horizontal">
+						<div class="col-md-3"><label class="control-label" for="ca_file"><?php echo _("Or Upload File")?></label></div>
+						<div class="col-md-9">
+							<input type="file" id="ca_file" name="ca_file" accept=".pem,.crt,.cer">
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="element-container">
+				<div class="row">
+					<div class="col-md-9 col-md-offset-3">
+						<button type="submit" class="btn btn-primary"><i class="fa fa-upload"></i> <?php echo _("Install CA")?></button>
+					</div>
+				</div>
+			</div>
+		</form>
+		</div>
+	</div>
+
+	<div class="display full-border">
+		<!-- Trust stores -->
+		<div class="section-title"><h3><i class="fa fa-folder-open"></i>&nbsp;<?php echo _("Trust Stores")?></h3></div>
+		<table class="table table-striped">
+			<thead>
+				<tr>
+					<th><?php echo _("Path")?></th>
+					<th><?php echo _("Description")?></th>
+					<th><?php echo _("Status")?></th>
+					<th><?php echo _("Certificates")?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach($sources as $s) { ?>
+					<tr>
+						<td><code><?php echo htmlspecialchars($s['path'], ENT_QUOTES); ?></code></td>
+						<td><?php echo htmlspecialchars($s['label'], ENT_QUOTES); ?></td>
+						<td>
+							<?php if(!empty($s['exists'])) { ?>
+								<span class="label label-success"><?php echo _("Present")?></span>
+							<?php } else { ?>
+								<span class="label label-default"><?php echo _("Not found")?></span>
+							<?php } ?>
+						</td>
+						<td><?php echo (int)$s['count']; ?></td>
+					</tr>
+				<?php } ?>
+			</tbody>
+		</table>
+
+		<!-- CA certificates -->
+		<div class="section-title"><h3><i class="fa fa-certificate"></i>&nbsp;<?php echo sprintf(_("Trusted CA Certificates (%d)"), count($cas))?></h3></div>
+		<table data-toggle="table" data-pagination="true" data-page-size="25" data-search="true" data-show-columns="true" class="table table-striped">
+			<thead>
+				<tr>
+					<th data-sortable="true"><?php echo _("Common Name / Organization")?></th>
+					<th data-sortable="true"><?php echo _("Issuer")?></th>
+					<th data-sortable="true"><?php echo _("Type")?></th>
+					<th data-sortable="true" data-field="expires"><?php echo _("Expires")?></th>
+					<th><?php echo _("SHA1 Fingerprint")?></th>
+					<th><?php echo _("Source File")?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach($cas as $ca) {
+					$expired = (!empty($ca['validTo_time_t']) && $ca['validTo_time_t'] < $now);
+				?>
+					<tr>
+						<td><strong><?php echo htmlspecialchars($ca['cn'], ENT_QUOTES); ?></strong>
+							<i class="fa fa-question-circle fpbx-help-icon" title="<?php echo htmlspecialchars($ca['subject'], ENT_QUOTES); ?>"></i>
+						</td>
+						<td><?php echo htmlspecialchars($ca['issuer'], ENT_QUOTES); ?></td>
+						<td>
+							<?php if(!empty($ca['selfSigned'])) { ?>
+								<span class="label label-primary"><?php echo _("Root (self-signed)")?></span>
+							<?php } else { ?>
+								<span class="label label-info"><?php echo _("Intermediate")?></span>
+							<?php } ?>
+						</td>
+						<td data-value="<?php echo (int)$ca['validTo_time_t']; ?>">
+							<?php
+								echo !empty($ca['validTo_time_t']) ? date('Y-m-d', $ca['validTo_time_t']) : '-';
+								if($expired) { echo ' <span class="label label-danger">'._("Expired").'</span>'; }
+							?>
+						</td>
+						<td><small><code><?php echo htmlspecialchars($ca['fingerprint'], ENT_QUOTES); ?></code></small></td>
+						<td><small><?php echo htmlspecialchars($ca['source'], ENT_QUOTES); ?></small></td>
+					</tr>
+				<?php } ?>
+			</tbody>
+		</table>
+	</div>
+</div>


### PR DESCRIPTION
## Summary

Adds the ability to issue Let's Encrypt certificates against a **private / self-hosted ACME server** (not only the public service) over the existing `http-01` challenge, plus tooling to manage the CA certificates the server trusts.

Motivation: many deployments run an internal ACME-compatible CA (step-ca, Boulder, Pebble, …) and need certman to talk to it instead of `acme-v02.api.letsencrypt.org`.

## What's included

### 1. Private / self-hosted ACME server support
- New per-certificate fields in the Let's Encrypt form (and `fwconsole` options):
  - **Custom ACME Server URL** — the full ACME *directory* URL. Empty = public Let's Encrypt (unchanged behaviour).
  - **ACME Server CA Bundle** — optional PEM CA bundle for servers whose TLS endpoint is signed by a private CA.
  - **Skip ACME Server TLS Verification** — optional, for self-signed setups on trusted networks.
- New `AcmeHttpClient` transport implementing `Analogic\ACME\ClientInterface` (does **not** patch the vendored `lescript`, so it survives composer updates). It supports an explicit directory URL (so non-standard paths like step-ca's `/acme/<provisioner>/directory` or Pebble's `/dir` work), a custom CA bundle (`CURLOPT_CAINFO`) and an optional insecure mode.
- `updateLE()` points lescript at the configured directory and **skips the public `mirror1.freepbx.org` reachability probe** when a custom server is used (it's only meaningful for the public service). Settings are persisted per certificate and **inherited automatically by the renewal paths** (cron + web).
- CLI: `fwconsole certificates --generate --type le ... --acme-url=<dir> [--acme-ca=<pem>] [--acme-insecure]`.

### 2. Installed-CA viewer
- New **Installed CAs** page (linked from the certificate list) listing the CA certificates trusted by this server: trust-store paths with certificate counts, and a searchable table of each CA (CN, issuer, root/intermediate, expiry, SHA-1 fingerprint, source file).
- Detects the distribution family (Debian vs RHEL) and shows only the relevant trust stores; falls back to showing all when it can't be determined. The active PHP/cURL bundle is always shown.
- Purpose: confirm a private ACME server's CA is already trusted and locate a usable CA bundle path.

### 3. Install a CA into the system trust store (web + CLI)
- A collapsible **Install a CA Certificate** card on the Installed CAs page (paste PEM or upload a file).
- Because the web process is unprivileged, the install runs as root via a new **Sysadmin incron hook** (`hooks/install-ca`): the web side stages the PEM and the hook copies it into the distribution trust anchors and runs `update-ca-trust` / `update-ca-certificates`. Installation is confirmed by re-scanning the trust store by fingerprint.
- CLI: `fwconsole certificates --install-ca=/path/to/ca.pem` (runs the hook directly when root).
- Requires the Sysadmin module; the UI states this clearly.

## Security notes
- Installing a CA into the system trust store is a powerful, admin-only action (a malicious CA enables TLS interception); the form warns about this.
- TLS verification of the ACME server stays **on** by default; "insecure" is opt-in per certificate.

## Files of note
- `Acme/AcmeHttpClient.php` (new) — custom ACME transport.
- `hooks/install-ca` (new) — privileged CA install hook.
- `views/systemcas.php` (new) — Installed CAs page + install form.
- `Certman.class.php`, `Console/Certman.class.php`, `views/le.php`, `views/certgrid.php`, `assets/js/certman.js`, `module.xml`.

## Testing
- Public Let's Encrypt issuance/renewal: unchanged (custom fields empty → original code path).
- Private ACME (step-ca / Pebble) over `http-01`: issued and renewed against the configured directory.
- Installed CAs page renders the trust store on Debian and RHEL family systems.
- CA install via web (Sysadmin hook): **pending** — blocked on an unsigned dev build (see Known limitations). The `fwconsole --install-ca` path (root, no hook) works.

## Known limitations / pending testing

> ⚠️ **CA install into the system trust store is not yet fully verified.**
> The privileged install relies on the Sysadmin incron hook runner, which only
> executes hooks from a **signed** module. On an unsigned/development build of
> this module the `hooks/install-ca` hook did not run, so the end-to-end "Install
> a CA" flow (web upload → root hook → `update-ca-trust`/`update-ca-certificates`)
> still needs to be validated on a properly signed module.
>
> Not affected: the private ACME server support and the Installed-CAs viewer work
> independently of the hook. When running as root, `fwconsole certificates
> --install-ca=<pem>` also bypasses the hook (it invokes the install logic
> directly) and can be used to verify the install path in the meantime.