### PR TITLE
feat: Private ACME server support, installed-CA viewer, and CA install into the system trust store (freepbx 17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 assets/less/cache
 module.sig
-ca-staging

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 assets/less/cache
 module.sig
+ca-staging

--- a/Acme/AcmeHttpClient.php
+++ b/Acme/AcmeHttpClient.php
@@ -1,0 +1,141 @@
+<?php
+// vim: set ai ts=4 sw=4 ft=php:
+//	License for all code of this FreePBX module can be found in the license file inside the module directory
+namespace FreePBX\modules\Certman;
+
+use Analogic\ACME\ClientInterface;
+use RuntimeException;
+
+/**
+ * ACME HTTP client for private / self-hosted Let's Encrypt-compatible servers.
+ *
+ * It mirrors \Analogic\ACME\Client (the default lescript transport) but adds the
+ * pieces needed to talk to an internal ACME server using http-01:
+ *
+ *   - An explicit directory URL. lescript always requests the directory through
+ *     the relative path '/directory', but private servers expose it elsewhere
+ *     (step-ca: /acme/<provisioner>/directory, Pebble: /dir, ...). When a
+ *     directory URL is configured we substitute it for that relative request.
+ *   - An optional custom CA bundle (CURLOPT_CAINFO) for servers presenting a
+ *     certificate signed by a private CA.
+ *   - An optional insecure mode that skips TLS verification for self-signed
+ *     setups. Off by default; only used when the operator explicitly opts in.
+ *
+ * Keeping this in the module (rather than patching vendor/) means a composer
+ * update of analogic/lescript will not wipe the customisation.
+ */
+#[\AllowDynamicProperties]
+class AcmeHttpClient implements ClientInterface
+{
+	private $lastCode;
+	private $lastHeader;
+	private $base;
+	private $directoryUrl;
+	private $caBundle;
+	private $insecure;
+
+	/**
+	 * @param string      $base         Origin (scheme://host[:port]) used for any relative request
+	 * @param string|null $directoryUrl Full ACME directory URL (substituted for lescript's '/directory')
+	 * @param string|null $caBundle     Path to a PEM CA bundle that signs the ACME server certificate
+	 * @param bool        $insecure     Skip TLS verification of the ACME server (self-signed)
+	 */
+	public function __construct($base, $directoryUrl = null, $caBundle = null, $insecure = false)
+	{
+		$this->base = rtrim((string)$base, '/');
+		$this->directoryUrl = $directoryUrl;
+		$this->caBundle = $caBundle;
+		$this->insecure = (bool)$insecure;
+	}
+
+	private function curl($method, $url, $data = null)
+	{
+		// lescript always fetches the directory via the relative path '/directory'.
+		// Private servers expose it on non-standard paths, so honour the explicit URL.
+		if ($url === '/directory' && !empty($this->directoryUrl)) {
+			$url = $this->directoryUrl;
+		}
+
+		$headers = array('Accept: application/json', 'Content-Type: application/jose+json');
+		$handle = curl_init();
+		curl_setopt($handle, CURLOPT_URL, preg_match('~^http~', $url) ? $url : $this->base.$url);
+		curl_setopt($handle, CURLOPT_HTTPHEADER, $headers);
+		curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($handle, CURLOPT_HEADER, true);
+
+		if (!empty($this->caBundle)) {
+			curl_setopt($handle, CURLOPT_CAINFO, $this->caBundle);
+		}
+		if ($this->insecure) {
+			curl_setopt($handle, CURLOPT_SSL_VERIFYHOST, 0);
+			curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, false);
+		}
+
+		switch ($method) {
+			case 'GET':
+				break;
+			case 'POST':
+				curl_setopt($handle, CURLOPT_POST, true);
+				curl_setopt($handle, CURLOPT_POSTFIELDS, $data);
+				break;
+		}
+		$response = curl_exec($handle);
+
+		if (curl_errno($handle)) {
+			throw new RuntimeException('Curl: '.curl_error($handle));
+		}
+
+		$header_size = curl_getinfo($handle, CURLINFO_HEADER_SIZE);
+
+		$header = substr($response, 0, $header_size);
+		$body = substr($response, $header_size);
+
+		$this->lastHeader = $header;
+		$this->lastCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+
+		if ($this->lastCode >= 400 && $this->lastCode < 600) {
+			throw new RuntimeException($this->lastCode."\n".$body);
+		}
+
+		$data = json_decode($body, true);
+		return $data === null ? $body : $data;
+	}
+
+	public function post($url, $data)
+	{
+		return $this->curl('POST', $url, $data);
+	}
+
+	public function get($url)
+	{
+		return $this->curl('GET', $url);
+	}
+
+	public function getLastNonce()
+	{
+		if (preg_match('~Replay-Nonce: (.+)~i', $this->lastHeader, $matches)) {
+			return trim($matches[1]);
+		}
+
+		throw new RuntimeException("We don't have nonce");
+	}
+
+	public function getLastLocation()
+	{
+		if (preg_match('~Location: (.+)~i', $this->lastHeader, $matches)) {
+			return trim($matches[1]);
+		}
+		return null;
+	}
+
+	public function getLastCode()
+	{
+		return $this->lastCode;
+	}
+
+	public function getLastLinks()
+	{
+		preg_match_all('~Link: <(.+)>;rel="up"~', $this->lastHeader, $matches);
+		return $matches[1];
+	}
+}

--- a/Api/Gql/Certman.php
+++ b/Api/Gql/Certman.php
@@ -97,6 +97,15 @@ class Certman extends Base {
 							return $this->updateDefaultCertificate($input);
 						}
 					]),
+					'generateLetsEncrypt' => Relay::mutationWithClientMutationId([
+						'name' => _('generateLetsEncrypt'),
+						'description' => _('Generate a Let\'s Encrypt certificate against the public service or a private/self-hosted ACME server (provide its directory URL)'),
+						'inputFields' => $this->getLEInputFields(),
+						'outputFields' => $this->getOutputFields(),
+						'mutateAndGetPayload' => function($input){
+							return $this->generateLetsEncrypt($input);
+						}
+					]),
 				];
 			};
 		}
@@ -217,6 +226,52 @@ class Certman extends Base {
 	}
 	
 	/**
+	 * getLEInputFields
+	 *
+	 * Inputs for a Let's Encrypt generation. The acme* fields are optional and,
+	 * when acmeUrl is provided, target a private/self-hosted ACME server instead
+	 * of the public Let's Encrypt service.
+	 *
+	 * @return array
+	 */
+	private function getLEInputFields(){
+		return [
+			'hostName' => [
+				'type' => Type::nonNull(Type::string()),
+				'description' => _('The fully qualified host name (FQDN) to request the certificate for. It must resolve to this machine and be reachable on port 80.')
+			],
+			'email' => [
+				'type' => Type::string(),
+				'description' => _("Optional. Account contact email, used only when the ACME account is first created. Many private ACME servers do not require it.")
+			],
+			'country' => [
+				'type' => Type::string(),
+				'description' => _('Optional. Two letter country code for the certificate subject (e.g. "US"). Defaults to "CA" if omitted; ACME CAs typically ignore it (only CN/SAN matter).')
+			],
+			'state' => [
+				'type' => Type::string(),
+				'description' => _('Optional. State or province for the certificate subject. Defaults to "Ontario" if omitted and is generally ignored by the CA.')
+			],
+			'san' => [
+				'type' => Type::listOf(Type::string()),
+				'description' => _('Optional list of Subject Alternative Names (additional host names) to include in the certificate.')
+			],
+			'acmeUrl' => [
+				'type' => Type::string(),
+				'description' => _('Optional. Directory URL of a private/self-hosted ACME (Let\'s Encrypt compatible) server. Leave empty to use the public Let\'s Encrypt service.')
+			],
+			'acmeCaBundle' => [
+				'type' => Type::string(),
+				'description' => _('Optional. Path to the CA bundle that signed the private ACME server certificate (used to verify TLS to that server).')
+			],
+			'acmeInsecure' => [
+				'type' => Type::boolean(),
+				'description' => _('Optional. Skip TLS verification of the private ACME server. Not recommended; use acmeCaBundle instead.')
+			]
+		];
+	}
+
+	/**
 	 * getInputFields
 	 *
 	 * @return void
@@ -270,6 +325,79 @@ class Certman extends Base {
 		return array('status' => true, 'message' => _('Added new certificate signing request'));
 	}
 	
+	/**
+	 * generateLetsEncrypt
+	 *
+	 * Generate a Let's Encrypt certificate (public service or a private/self-hosted
+	 * ACME server when acmeUrl is supplied). Runs synchronously and returns once the
+	 * certificate has been issued and saved. Mirrors the web/CLI generation flow.
+	 *
+	 * @param  array $input
+	 * @return array array('status'=>bool, 'message'=>string)
+	 */
+	private function generateLetsEncrypt($input){
+		$certman = $this->freepbx->certman;
+
+		$host  = isset($input['hostName']) ? basename(strtolower(trim($input['hostName']))) : '';
+		$email = isset($input['email'])   ? trim($input['email']) : '';
+		$C     = isset($input['country']) ? trim($input['country']) : '';
+		$ST    = isset($input['state'])   ? trim($input['state']) : '';
+		$acmeUrl = !empty($input['acmeUrl']) ? trim($input['acmeUrl']) : '';
+		if ($host === '') {
+			return array('status' => false, 'message' => _('hostName is required'));
+		}
+		// The public Let's Encrypt service requires country and email; a private ACME
+		// server (acmeUrl) only needs the host (updateLE defaults state, etc.).
+		if ($acmeUrl === '' && ($email === '' || $C === '')) {
+			return array('status' => false, 'message' => _('country and email are required for the public Let\'s Encrypt service'));
+		}
+		if ($certman->checkCertificateName($host)) {
+			return array('status' => false, 'message' => sprintf(_('%s already exists'), $host));
+		}
+
+		// Subject Alternative Names (optional); never duplicate the primary host.
+		$san = array();
+		if (!empty($input['san']) && is_array($input['san'])) {
+			$san = array_unique(array_filter(array_map(function($v){ return strtolower(trim($v)); }, $input['san'])));
+			$key = array_search($host, $san);
+			if ($key !== false) { unset($san[$key]); }
+			sort($san);
+		}
+		$description = $host;
+		if (!empty($san)) { $description .= ', ' . implode(', ', $san); }
+
+		// Private/self-hosted ACME server (optional). Empty acmeUrl uses the public service.
+		$acmeUrl      = !empty($input['acmeUrl'])      ? trim($input['acmeUrl']) : '';
+		$acmeCaBundle = !empty($input['acmeCaBundle']) ? trim($input['acmeCaBundle']) : '';
+		$acmeInsecure = !empty($input['acmeInsecure']);
+
+		$additional = array('C' => $C, 'ST' => $ST, 'email' => $email);
+		if (!empty($san)) { $additional['san'] = $san; }
+		if ($acmeUrl !== '') {
+			$additional['acmeUrl']      = $acmeUrl;
+			$additional['acmeCaBundle'] = $acmeCaBundle;
+			$additional['acmeInsecure'] = $acmeInsecure;
+		}
+
+		try {
+			$certman->updateLE($host, array(
+				'countryCode'   => $C,
+				'state'         => $ST,
+				'challengetype' => 'http', // https will not work
+				'email'         => $email,
+				'san'           => $san,
+				'acmeUrl'       => $acmeUrl,
+				'acmeCaBundle'  => $acmeCaBundle,
+				'acmeInsecure'  => $acmeInsecure,
+			), false, true);
+			$certman->saveCertificate(null, $host, $description, 'le', $additional);
+		} catch (\Exception $e) {
+			return array('status' => false, 'message' => sprintf(_('Let\'s Encrypt generation failed: %s'), $e->getMessage()));
+		}
+
+		return array('status' => true, 'message' => sprintf(_('Let\'s Encrypt certificate generated for %s'), $host));
+	}
+
 	/**
 	 * resolveNames
 	 *

--- a/Backup.php
+++ b/Backup.php
@@ -7,8 +7,7 @@ class Backup Extends Base\BackupBase{
   public $dirs = [];
   public function runBackup($id,$transaction){
     $this->certman = $this->FreePBX->Certman;
-    $this->buildFileStructure()
-      ->addDirectories($this->dirs);
+    $this->buildFileStructure()->addDirectories($this->dirs);
     $this->addDependency('core');
     $this->addConfigs($this->buildConfigs());
   }
@@ -18,6 +17,9 @@ class Backup Extends Base\BackupBase{
       'managedCerts' => $this->certman->getAllManagedCertificates(),
       'managedCSRs' => $this->certman->getAllManagedCSRs(),
       'dtlsOptions' => $this->certman->getAllDTLSOptions(),
+      // Dump the whole module KVStore (Certman extends DB_Helper) - this captures
+      // the system trust-store CAs (id 'systemcas') and any future KVStore data.
+      'kvstore' => $this->dumpKVStore(),
       'keyDir' => $this->certman->PKCS->getKeysLocation()
     ];
   }

--- a/Certman.class.php
+++ b/Certman.class.php
@@ -928,31 +928,51 @@ class Certman implements BMO {
 		if ($pem === '') {
 			return array('status' => false, 'message' => _('No certificate data provided'));
 		}
+		if (strlen($pem) > 100000) {
+			return array('status' => false, 'message' => _('The supplied certificate data is too large.'));
+		}
+		// Never accept a private key here - we only install public CA certificates.
+		if (stripos($pem, 'PRIVATE KEY') !== false) {
+			return array('status' => false, 'message' => _('The supplied data contains a private key; provide only the CA certificate.'));
+		}
+		// Exactly one certificate, so the operator sees precisely what is trusted
+		// and we never trust extra certificates hidden in a bundle.
+		if (substr_count($pem, '-----BEGIN CERTIFICATE-----') !== 1) {
+			return array('status' => false, 'message' => _('Please provide exactly one CA certificate in PEM format.'));
+		}
 
 		$info = @openssl_x509_parse($pem);
 		if (empty($info)) {
 			return array('status' => false, 'message' => _('The supplied data is not a valid PEM certificate'));
 		}
 		$fp = @openssl_x509_fingerprint($pem, 'sha1');
-		$cn = $info['subject']['CN'] ?? ($info['subject']['O'] ?? 'ca');
+		$rawCn = $info['subject']['CN'] ?? ($info['subject']['O'] ?? 'ca');
+		// The CN comes from an attacker-controlled certificate and is rendered as
+		// HTML in the web message, so escape it for display.
+		$cn = htmlspecialchars((string)$rawCn, ENT_QUOTES);
 		// A trust anchor should be a CA; warn (but don't block) if it is not.
 		$isCa = !empty($info['extensions']['basicConstraints']) && stripos($info['extensions']['basicConstraints'], 'CA:TRUE') !== false;
 
-		// Build a safe target basename.
-		$name = $friendlyName !== '' ? $friendlyName : $cn;
+		// Build a safe, collision-resistant target basename (name + fingerprint).
+		$name = $friendlyName !== '' ? $friendlyName : $rawCn;
 		$name = preg_replace('/[^A-Za-z0-9._-]+/', '_', (string)$name);
 		$name = trim($name, '._-');
 		if ($name === '') { $name = 'ca'; }
-		$base = 'certman-' . $name;
+		$fpShort = $fp ? substr(preg_replace('/[^a-f0-9]/i', '', $fp), 0, 12) : '';
+		$base = 'certman-' . $name . ($fpShort !== '' ? '-' . $fpShort : '');
 
 		// Stage the PEM where the root hook can read it.
 		$staging = __DIR__ . '/ca-staging';
 		if (!is_dir($staging) && !@mkdir($staging, 0775, true)) {
 			return array('status' => false, 'message' => sprintf(_('Unable to create staging directory %s'), $staging));
 		}
+		// Clean slate: drop any leftover staged files so the root hook only ever
+		// processes the certificate we are about to write.
+		foreach ((array)glob($staging . '/*.{crt,result}', GLOB_BRACE) as $stale) {
+			@unlink($stale);
+		}
 		$crtFile = $staging . '/' . $base . '.crt';
 		$resultFile = $staging . '/' . $base . '.result';
-		@unlink($resultFile);
 		if (@file_put_contents($crtFile, $pem . "\n") === false) {
 			return array('status' => false, 'message' => _('Unable to stage the certificate for installation'));
 		}
@@ -960,8 +980,8 @@ class Certman implements BMO {
 		// Run the privileged install.
 		try {
 			if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
-				// Already root (e.g. fwconsole) - run the hook directly.
-				exec(escapeshellarg(__DIR__ . '/hooks/install-ca') . ' 2>&1');
+				// Already root (e.g. fwconsole) - run the hook directly, restricted to our file.
+				exec(escapeshellarg(__DIR__ . '/hooks/install-ca') . ' ' . escapeshellarg($base . '.crt') . ' 2>&1');
 			} else {
 				$this->runHook('install-ca');
 				// incron is asynchronous; wait for the hook to drop its result file.
@@ -980,9 +1000,14 @@ class Certman implements BMO {
 		@unlink($resultFile);
 		@unlink($crtFile); // the hook removes it on success; clean up just in case
 
-		// Confirm the certificate is now present in the trust store.
-		$installed = false;
-		if ($fp) {
+		// The hook is authoritative: it reports "OK" only after update-ca-* actually
+		// succeeded (and rolls the anchor back otherwise).
+		$hookOk = ($hookResult !== '' && stripos($hookResult, 'OK') === 0);
+
+		// Only when the hook left no result (e.g. it ran fully out-of-band) do we
+		// fall back to confirming the certificate is present in the trust store.
+		$installed = $hookOk;
+		if (!$installed && $hookResult === '' && $fp) {
 			$target = strtoupper(implode(':', str_split($fp, 2)));
 			$sys = $this->getSystemCAs();
 			foreach ($sys['cas'] as $c) {
@@ -998,7 +1023,7 @@ class Certman implements BMO {
 			return $result;
 		}
 
-		$detail = $hookResult !== '' ? $hookResult : _('the certificate was staged but could not be confirmed in the system trust store. Ensure the Sysadmin module is installed and up to date.');
+		$detail = $hookResult !== '' ? htmlspecialchars($hookResult, ENT_QUOTES) : _('the certificate was staged but could not be confirmed in the system trust store. Ensure the Sysadmin module is installed and up to date.');
 		return array('status' => false, 'message' => sprintf(_('Could not confirm installation of CA "%s": %s'), $cn, $detail));
 	}
 

--- a/Certman.class.php
+++ b/Certman.class.php
@@ -132,6 +132,22 @@ class Certman implements BMO {
 		$request = $_REQUEST;
 		$request['certaction'] = !empty($request['certaction']) ? $request['certaction'] : "";
 		switch($request['certaction']) {
+			case "installca":
+				$pem = '';
+				if (!empty($_FILES['ca_file']['tmp_name']) && is_uploaded_file($_FILES['ca_file']['tmp_name'])) {
+					$pem = (string)file_get_contents($_FILES['ca_file']['tmp_name']);
+				} elseif (!empty($_POST['ca_pem'])) {
+					$pem = (string)$_POST['ca_pem'];
+				}
+				$res = $this->installSystemCA($pem, $_POST['ca_name'] ?? '');
+				if (!empty($res['status'])) {
+					$msg = $res['message'];
+					if (!empty($res['warning'])) { $msg .= ' ' . $res['warning']; }
+					$this->message = array('type' => 'success', 'message' => $msg);
+				} else {
+					$this->message = array('type' => 'danger', 'message' => $res['message']);
+				}
+			break;
 			case "importlocally":
 				$processed = $this->importLocalCertificates();
 				if(!empty($processed)) {
@@ -206,6 +222,9 @@ class Certman implements BMO {
 						}
 						$removeDstRootCaX3 = (isset($_POST['removeDstRootCaX3']) && $_POST['removeDstRootCaX3']) ? true : false;
 
+						$acmeUrl = !empty($_POST['acme_url']) ? trim($_POST['acme_url']) : '';
+						$acmeCaBundle = !empty($_POST['acme_ca']) ? trim($_POST['acme_ca']) : '';
+						$acmeInsecure = (!empty($_POST['acme_insecure'])) ? true : false;
 						if(!empty($cert)) {
 							$additional = array(
 								"C" => $_POST['C'],
@@ -214,6 +233,11 @@ class Certman implements BMO {
 								"removeDstRootCaX3" => $removeDstRootCaX3,
 							);
 							if (!empty($san)) {$additional['san'] = $san;}
+							if ($acmeUrl !== '') {
+								$additional['acmeUrl'] = $acmeUrl;
+								$additional['acmeCaBundle'] = $acmeCaBundle;
+								$additional['acmeInsecure'] = $acmeInsecure;
+							}
 							$removeDstRootCaX3 = (isset($_POST['removeDstRootCaX3']) && $_POST['removeDstRootCaX3']) ? true : false;
 							// check cert expiration
 							$cert = $this->getCertificateDetails($_POST['cid']);
@@ -235,7 +259,10 @@ class Certman implements BMO {
 									"challengetype" => "http", // https will not work.
 									"email" => $_POST['email'],
 									"san" => $san,
-									"removeDstRootCaX3" => $removeDstRootCaX3
+									"removeDstRootCaX3" => $removeDstRootCaX3,
+									"acmeUrl" => $acmeUrl,
+									"acmeCaBundle" => $acmeCaBundle,
+									"acmeInsecure" => $acmeInsecure
 								), false, true);
 							} catch(Exception $e) {
 								$lelog = trim(ob_get_contents());
@@ -297,6 +324,9 @@ class Certman implements BMO {
 							$description .= ", " . implode(", ", $san);
 						}
 						$removeDstRootCaX3 = (!empty($_POST['removeDstRootCaX3']) && $_POST['removeDstRootCaX3'] ? true : false);
+						$acmeUrl = !empty($_POST['acme_url']) ? trim($_POST['acme_url']) : '';
+						$acmeCaBundle = !empty($_POST['acme_ca']) ? trim($_POST['acme_ca']) : '';
+						$acmeInsecure = (!empty($_POST['acme_insecure'])) ? true : false;
 						$additional = array(
 								"C" => $_POST['C'],
 								"ST" => $_POST['ST'],
@@ -304,6 +334,11 @@ class Certman implements BMO {
 								"removeDstRootCaX3" => $removeDstRootCaX3,
 						);
 						if (!empty($san)) {$additional['san'] = $san;}
+						if ($acmeUrl !== '') {
+							$additional['acmeUrl'] = $acmeUrl;
+							$additional['acmeCaBundle'] = $acmeCaBundle;
+							$additional['acmeInsecure'] = $acmeInsecure;
+						}
 						ob_start();
 						try{
 							if($this->checkCertificateName($host)) {
@@ -316,6 +351,9 @@ class Certman implements BMO {
 								"email" => $_POST['email'],
 								"san" => $san,
 								"removeDstRootCaX3" => $removeDstRootCaX3,
+								"acmeUrl" => $acmeUrl,
+								"acmeCaBundle" => $acmeCaBundle,
+								"acmeInsecure" => $acmeInsecure,
 							));
 							$this->saveCertificate(null, $host, $description, 'le', $additional);
 						} catch(Exception $e) {
@@ -543,6 +581,10 @@ class Certman implements BMO {
 					}
 				}
 			break;
+			case 'systemcas':
+				$systemcas = $this->getSystemCAs();
+				echo load_view(__DIR__.'/views/systemcas.php',array('systemcas' => $systemcas, 'message' => $this->message));
+			break;
 			default:
 				$certs = $this->getAllManagedCertificates();
 				$csr = $this->checkCSRexists();
@@ -626,6 +668,9 @@ class Certman implements BMO {
 							"email" => $cert['additional']['email'] ?? '',
 							"san" => $cert['additional']['san'] ?? '',
 							"removeDstRootCaX3" => $cert['additional']['removeDstRootCaX3'] ?? '',
+							"acmeUrl" => $cert['additional']['acmeUrl'] ?? '',
+							"acmeCaBundle" => $cert['additional']['acmeCaBundle'] ?? '',
+							"acmeInsecure" => $cert['additional']['acmeInsecure'] ?? false,
 						);
 
 						$this->updateLE($cert['info']['crt']['subject']['CN'], $settings, false, $force);
@@ -669,6 +714,9 @@ class Certman implements BMO {
 							"email" => $cert['additional']['email'] ?? '',
 							"san" => $cert['additional']['san'] ?? '',
 							"removeDstRootCaX3" => $cert['additional']['removeDstRootCaX3'] ?? '',
+							"acmeUrl" => $cert['additional']['acmeUrl'] ?? '',
+							"acmeCaBundle" => $cert['additional']['acmeCaBundle'] ?? '',
+							"acmeInsecure" => $cert['additional']['acmeInsecure'] ?? false,
 						);
 
 						$this->updateLE($cert['info']['crt']['subject']['CN'], $settings, false, $force);
@@ -744,6 +792,217 @@ class Certman implements BMO {
 	}
 
 	/**
+	 * Render an openssl DN array (subject/issuer) as a readable string.
+	 * @param array $dn
+	 * @return string
+	 */
+	private function dnToString($dn) {
+		$parts = array();
+		foreach ((array)$dn as $k => $v) {
+			if (is_array($v)) { $v = implode('+', $v); }
+			$parts[] = $k . '=' . $v;
+		}
+		return implode(', ', $parts);
+	}
+
+	/**
+	 * Detect which distribution trust-store family this server uses.
+	 * @return string 'debian', 'rhel', or '' when it can't be determined
+	 */
+	private function detectTrustStoreFamily() {
+		if (is_file('/etc/redhat-release')) { return 'rhel'; }
+		if (is_file('/etc/debian_version')) { return 'debian'; }
+		// Fall back to the presence of the trust tooling / anchor directories.
+		$hasRhel   = is_dir('/etc/pki/ca-trust/source/anchors') || (function_exists('fpbx_which') && fpbx_which('update-ca-trust'));
+		$hasDebian = is_dir('/usr/local/share/ca-certificates') || (function_exists('fpbx_which') && fpbx_which('update-ca-certificates'));
+		if ($hasRhel && !$hasDebian) { return 'rhel'; }
+		if ($hasDebian && !$hasRhel) { return 'debian'; }
+		return ''; // unknown or ambiguous - show everything
+	}
+
+	/**
+	 * Enumerate the CA certificates trusted by this server.
+	 *
+	 * Reads the active system CA bundle (the one PHP/cURL resolve to) plus the
+	 * common distribution bundle files and custom trust-anchor directories, then
+	 * returns the parsed certificates. This is primarily a helper for operators
+	 * configuring a private/self-hosted ACME server: it lets them confirm the
+	 * ACME server's CA is already trusted and locate a CA bundle path to use in
+	 * the "ACME Server CA Bundle" field.
+	 *
+	 * @return array array('sources' => array(...), 'cas' => array(...))
+	 */
+	public function getSystemCAs() {
+		$candidates = array();
+
+		// Whatever PHP/cURL currently resolve to (file or directory).
+		$primary = $this->getCABundle();
+		if (!empty($primary)) {
+			$candidates[$primary] = _('Active system CA bundle (used by PHP/cURL)');
+		}
+
+		// Common distribution bundle files and custom anchor directories, each
+		// tagged with the distro family it belongs to ('any' = generic).
+		$known = array(
+			'/etc/ssl/certs/ca-certificates.crt' => array('label' => _('Debian/Ubuntu system bundle'),        'family' => 'debian'),
+			'/etc/pki/tls/certs/ca-bundle.crt'   => array('label' => _('RHEL/CentOS system bundle'),          'family' => 'rhel'),
+			'/etc/ssl/cert.pem'                  => array('label' => _('OpenSSL default bundle'),              'family' => 'any'),
+			'/usr/local/share/ca-certificates'   => array('label' => _('Custom CAs (Debian/Ubuntu anchors)'), 'family' => 'debian'),
+			'/etc/pki/ca-trust/source/anchors'   => array('label' => _('Custom CAs (RHEL/CentOS anchors)'),   'family' => 'rhel'),
+		);
+		// Only list stores that match the detected distro; show everything when unknown.
+		$family = $this->detectTrustStoreFamily();
+		foreach ($known as $path => $meta) {
+			if (isset($candidates[$path])) { continue; }
+			if ($family !== '' && $meta['family'] !== 'any' && $meta['family'] !== $family) { continue; }
+			$candidates[$path] = $meta['label'];
+		}
+
+		$sources = array();
+		$cas = array();
+		$seen = array(); // dedupe identical certs that appear in several stores
+
+		foreach ($candidates as $path => $label) {
+			$files = array();
+			if (is_dir($path)) {
+				foreach ((array)glob(rtrim($path, '/') . '/*') as $f) {
+					if (is_file($f)) { $files[] = $f; }
+				}
+			} elseif (is_file($path)) {
+				$files[] = $path;
+			} else {
+				$sources[] = array('path' => $path, 'label' => $label, 'exists' => false, 'count' => 0);
+				continue;
+			}
+
+			$count = 0;
+			foreach ($files as $f) {
+				$contents = @file_get_contents($f);
+				if ($contents === false) { continue; }
+				foreach ($this->parseCaBundle($contents) as $pem) {
+					if (strpos($pem, 'BEGIN CERTIFICATE') === false) { continue; }
+					$info = @openssl_x509_parse($pem);
+					if (empty($info)) { continue; }
+					$fp = @openssl_x509_fingerprint($pem, 'sha1');
+					if ($fp && isset($seen[$fp])) { continue; }
+					if ($fp) { $seen[$fp] = true; }
+					$count++;
+					$subject = $info['subject'] ?? array();
+					$issuer  = $info['issuer'] ?? array();
+					$cas[] = array(
+						'cn'               => $subject['CN'] ?? ($subject['O'] ?? ($subject['OU'] ?? _('(unnamed)'))),
+						'subject'          => $this->dnToString($subject),
+						'issuer'           => $this->dnToString($issuer),
+						'validFrom_time_t' => $info['validFrom_time_t'] ?? 0,
+						'validTo_time_t'   => $info['validTo_time_t'] ?? 0,
+						'selfSigned'       => ($subject == $issuer),
+						'fingerprint'      => $fp ? strtoupper(implode(':', str_split($fp, 2))) : '',
+						'source'           => $f,
+					);
+				}
+			}
+			$sources[] = array('path' => $path, 'label' => $label, 'exists' => true, 'count' => $count);
+		}
+
+		usort($cas, function ($a, $b) { return strcasecmp($a['cn'], $b['cn']); });
+
+		return array('sources' => $sources, 'cas' => $cas);
+	}
+
+	/**
+	 * Install a CA certificate into the system trust store.
+	 *
+	 * Validates the supplied PEM, stages it in the module's ca-staging directory
+	 * and triggers the privileged "install-ca" hook (run as root by the Sysadmin
+	 * incron runner) which copies it into the distribution trust anchors and
+	 * refreshes the trust store. When already running as root (e.g. fwconsole)
+	 * the hook is executed directly. Installation is confirmed by re-scanning the
+	 * trust store for the certificate fingerprint.
+	 *
+	 * @param  string $pem          PEM encoded CA certificate
+	 * @param  string $friendlyName Optional friendly name used for the stored filename
+	 * @return array  array('status' => bool, 'message' => string[, 'warning' => string])
+	 */
+	public function installSystemCA($pem, $friendlyName = '') {
+		$pem = trim((string)$pem);
+		if ($pem === '') {
+			return array('status' => false, 'message' => _('No certificate data provided'));
+		}
+
+		$info = @openssl_x509_parse($pem);
+		if (empty($info)) {
+			return array('status' => false, 'message' => _('The supplied data is not a valid PEM certificate'));
+		}
+		$fp = @openssl_x509_fingerprint($pem, 'sha1');
+		$cn = $info['subject']['CN'] ?? ($info['subject']['O'] ?? 'ca');
+		// A trust anchor should be a CA; warn (but don't block) if it is not.
+		$isCa = !empty($info['extensions']['basicConstraints']) && stripos($info['extensions']['basicConstraints'], 'CA:TRUE') !== false;
+
+		// Build a safe target basename.
+		$name = $friendlyName !== '' ? $friendlyName : $cn;
+		$name = preg_replace('/[^A-Za-z0-9._-]+/', '_', (string)$name);
+		$name = trim($name, '._-');
+		if ($name === '') { $name = 'ca'; }
+		$base = 'certman-' . $name;
+
+		// Stage the PEM where the root hook can read it.
+		$staging = __DIR__ . '/ca-staging';
+		if (!is_dir($staging) && !@mkdir($staging, 0775, true)) {
+			return array('status' => false, 'message' => sprintf(_('Unable to create staging directory %s'), $staging));
+		}
+		$crtFile = $staging . '/' . $base . '.crt';
+		$resultFile = $staging . '/' . $base . '.result';
+		@unlink($resultFile);
+		if (@file_put_contents($crtFile, $pem . "\n") === false) {
+			return array('status' => false, 'message' => _('Unable to stage the certificate for installation'));
+		}
+
+		// Run the privileged install.
+		try {
+			if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+				// Already root (e.g. fwconsole) - run the hook directly.
+				exec(escapeshellarg(__DIR__ . '/hooks/install-ca') . ' 2>&1');
+			} else {
+				$this->runHook('install-ca');
+				// incron is asynchronous; wait for the hook to drop its result file.
+				$waited = 0;
+				while (!file_exists($resultFile) && $waited < 20) {
+					usleep(500000);
+					$waited++;
+				}
+			}
+		} catch (\Exception $e) {
+			@unlink($crtFile);
+			return array('status' => false, 'message' => sprintf(_('Unable to run the privileged install hook: %s. The Sysadmin module is required to install CAs into the system trust store from the web interface.'), $e->getMessage()));
+		}
+
+		$hookResult = file_exists($resultFile) ? trim((string)@file_get_contents($resultFile)) : '';
+		@unlink($resultFile);
+		@unlink($crtFile); // the hook removes it on success; clean up just in case
+
+		// Confirm the certificate is now present in the trust store.
+		$installed = false;
+		if ($fp) {
+			$target = strtoupper(implode(':', str_split($fp, 2)));
+			$sys = $this->getSystemCAs();
+			foreach ($sys['cas'] as $c) {
+				if (!empty($c['fingerprint']) && $c['fingerprint'] === $target) { $installed = true; break; }
+			}
+		}
+
+		if ($installed) {
+			$result = array('status' => true, 'message' => sprintf(_('CA "%s" was installed into the system trust store.'), $cn));
+			if (!$isCa) {
+				$result['warning'] = _('Note: this certificate is not marked as a CA (basicConstraints CA:TRUE).');
+			}
+			return $result;
+		}
+
+		$detail = $hookResult !== '' ? $hookResult : _('the certificate was staged but could not be confirmed in the system trust store. Ensure the Sysadmin module is installed and up to date.');
+		return array('status' => false, 'message' => sprintf(_('Could not confirm installation of CA "%s": %s'), $cn, $detail));
+	}
+
+	/**
 	 * Parse CA bundle into an array
 	 * @param string $contents the contents of the bundle
 	 * 
@@ -808,6 +1067,12 @@ class Certman implements BMO {
 		$email = !empty($settings['email']) ? $settings['email'] : '';
 		$san = !empty($settings['san']) ? $settings['san'] : array();
 		$removeDstRootCaX3 = !empty($settings['removeDstRootCaX3']) ? $settings['removeDstRootCaX3'] : false;
+		// Custom / private ACME server (self-hosted Let's Encrypt compatible, http-01).
+		// When acmeUrl is set we point lescript at it instead of the public LE endpoint.
+		$acmeUrl = !empty($settings['acmeUrl']) ? trim($settings['acmeUrl']) : '';
+		$acmeCaBundle = !empty($settings['acmeCaBundle']) ? trim($settings['acmeCaBundle']) : '';
+		$acmeInsecure = !empty($settings['acmeInsecure']) ? true : false;
+		$useCustomAcme = ($acmeUrl !== '');
 
 		$location = $this->PKCS->getKeysLocation();
 		// $logger = $this->FreePBX->Logger->monoLog;
@@ -887,23 +1152,27 @@ class Certman implements BMO {
 
 			//Now check freepbx.org
 			//	on failure, save error as hint and continue
-				try {
-					$pest = new \PestJSON('http://mirror1.freepbx.org');
-					$pest->curl_opts[CURLOPT_FOLLOWLOCATION] = true;
-					$pest->curl_opts[CURLOPT_CONNECTTIMEOUT] = 10;
-					$pest->curl_opts[CURLOPT_TIMEOUT] = 30;
-					$thing = $pest->get('/lechecker.php', array('host' => $host, 'path' => $pathCheck, 'token' => $token, 'type' => $challengetype));
-					if(empty($thing)) {
-						$lecheckerr = _("No valid response from http://mirror1.freepbx.org");
-					} elseif(!$thing['status']) {
-						$lecheckerr = $thing['message'];
+			//	Skipped for a custom/private ACME server: that public reachability
+			//	probe is only meaningful for the public Let's Encrypt service.
+				if(!$useCustomAcme) {
+					try {
+						$pest = new \PestJSON('http://mirror1.freepbx.org');
+						$pest->curl_opts[CURLOPT_FOLLOWLOCATION] = true;
+						$pest->curl_opts[CURLOPT_CONNECTTIMEOUT] = 10;
+						$pest->curl_opts[CURLOPT_TIMEOUT] = 30;
+						$thing = $pest->get('/lechecker.php', array('host' => $host, 'path' => $pathCheck, 'token' => $token, 'type' => $challengetype));
+						if(empty($thing)) {
+							$lecheckerr = _("No valid response from http://mirror1.freepbx.org");
+						} elseif(!$thing['status']) {
+							$lecheckerr = $thing['message'];
+						}
+					} catch(Exception $e) {
+						$lecheckerr =  _("lechecker: ") . get_class($e) . " - " . trim(strip_tags($e->getMessage()));
 					}
-				} catch(Exception $e) {
-					$lecheckerr =  _("lechecker: ") . get_class($e) . " - " . trim(strip_tags($e->getMessage()));
-				}
-				if (isset($lecheckerr)) {
-					print($lecheckerr . "\n");
-					$hints[] = $lecheckerr;
+					if (isset($lecheckerr)) {
+						print($lecheckerr . "\n");
+						$hints[] = $lecheckerr;
+					}
 				}
 				@unlink($webroot.$pathCheck);
 			}
@@ -912,9 +1181,25 @@ class Certman implements BMO {
 			if($needsgen) {
 				$tokenpath = $webroot . "/.well-known/acme-challenge";
 				$prechallengefiles = glob($tokenpath .'/*'); // */
-				$le = new \Analogic\ACME\Lescript($location, $webroot, $logger);
-				if($staging) {
-					$le->ca = 'https://acme-staging.api.letsencrypt.org';
+				if($useCustomAcme) {
+					// Private ACME server: inject our own transport so lescript talks
+					// to the configured directory URL (and trusts a private CA if set).
+					require_once __DIR__ . '/Acme/AcmeHttpClient.php';
+					$origin = preg_replace('~^(https?://[^/]+).*~', '$1', $acmeUrl);
+					$client = new \FreePBX\modules\Certman\AcmeHttpClient(
+						$origin,
+						$acmeUrl,
+						($acmeCaBundle !== '' ? $acmeCaBundle : null),
+						$acmeInsecure
+					);
+					$le = new \Analogic\ACME\Lescript($location, $webroot, $logger, $client);
+					$le->ca = $acmeUrl;
+					print(sprintf(_("Using custom ACME server: %s\n"), $acmeUrl));
+				} else {
+					$le = new \Analogic\ACME\Lescript($location, $webroot, $logger);
+					if($staging) {
+						$le->ca = 'https://acme-staging.api.letsencrypt.org';
+					}
 				}
 				$le->countryCode = $countryCode;
 				$le->state = $state;

--- a/Certman.class.php
+++ b/Certman.class.php
@@ -14,8 +14,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use Exception;
 
-#[\AllowDynamicProperties]
-class Certman implements BMO {
+class Certman extends \FreePBX\DB_Helper implements BMO {
 	/* Asterisk Defaults */
 	private $defaults = array(
 		"sip" => array(
@@ -132,20 +131,53 @@ class Certman implements BMO {
 		$request = $_REQUEST;
 		$request['certaction'] = !empty($request['certaction']) ? $request['certaction'] : "";
 		switch($request['certaction']) {
-			case "installca":
+			case "savecert":
+				// Step 1: load/register the certificate (does NOT install it).
 				$pem = '';
 				if (!empty($_FILES['ca_file']['tmp_name']) && is_uploaded_file($_FILES['ca_file']['tmp_name'])) {
 					$pem = (string)file_get_contents($_FILES['ca_file']['tmp_name']);
 				} elseif (!empty($_POST['ca_pem'])) {
 					$pem = (string)$_POST['ca_pem'];
 				}
-				$res = $this->installSystemCA($pem, $_POST['ca_name'] ?? '');
+				$res = $this->saveSystemCA($pem, $_POST['ca_name'] ?? '');
 				if (!empty($res['status'])) {
 					$msg = $res['message'];
 					if (!empty($res['warning'])) { $msg .= ' ' . $res['warning']; }
 					$this->message = array('type' => 'success', 'message' => $msg);
 				} else {
 					$this->message = array('type' => 'danger', 'message' => $res['message']);
+				}
+			break;
+			case "installca":
+			case "uninstallca":
+				// Step 2: install / uninstall a loaded CA from the system trust store.
+				$fp = $_POST['fp'] ?? ($_REQUEST['fp'] ?? '');
+				$res = $this->setSystemCAInstall($fp, $request['certaction'] === 'installca');
+				if (!empty($res['status'])) {
+					$msg = $res['message'];
+					if (!empty($res['warning'])) { $msg .= ' ' . $res['warning']; }
+					$this->message = array('type' => 'success', 'message' => $msg);
+				} else {
+					$this->message = array('type' => 'danger', 'message' => $res['message']);
+				}
+			break;
+			case "reinstallca":
+				// Re-run the privileged reconcile to sync the trust store with the
+				// managed desired state (install missing, remove orphans).
+				$err = $this->triggerReconcile();
+				if ($err === '') {
+					$this->message = array('type' => 'success', 'message' => _("Reconcile triggered: the system trust store will be synced with the managed CAs."));
+				} else {
+					$this->message = array('type' => 'danger', 'message' => $err);
+				}
+			break;
+			case "removeca":
+				// Forget a CA entirely (and remove it from the system if installed).
+				$fp = $_POST['fp'] ?? ($_REQUEST['fp'] ?? '');
+				if ($this->removeManagedSystemCA($fp)) {
+					$this->message = array('type' => 'success', 'message' => _("CA removed from Certman and from the system trust store."));
+				} else {
+					$this->message = array('type' => 'danger', 'message' => _("Could not find that managed CA."));
 				}
 			break;
 			case "importlocally":
@@ -583,7 +615,26 @@ class Certman implements BMO {
 			break;
 			case 'systemcas':
 				$systemcas = $this->getSystemCAs();
-				echo load_view(__DIR__.'/views/systemcas.php',array('systemcas' => $systemcas, 'message' => $this->message));
+				// Annotate the managed (desired-state) CAs with whether each is
+				// actually present in the system trust store, so the view can flag
+				// drift (managed but missing).
+				$present = array();
+				foreach ($systemcas['cas'] as $c) {
+					if (!empty($c['fingerprint'])) { $present[$c['fingerprint']] = true; }
+				}
+				$managed = array();
+				foreach ($this->getManagedSystemCAs() as $fp => $rec) {
+					$target = strtoupper(implode(':', str_split($fp, 2)));
+					$managed[] = array(
+						'fp'          => $fp,
+						'fingerprint' => $target,
+						'cn'          => $rec['cn'] ?? ($rec['friendly'] ?? $fp),
+						'added'       => $rec['added'] ?? 0,
+						'wantInstall' => !empty($rec['install']),
+						'present'     => isset($present[$target]),
+					);
+				}
+				echo load_view(__DIR__.'/views/systemcas.php',array('systemcas' => $systemcas, 'managed' => $managed, 'message' => $this->message));
 			break;
 			default:
 				$certs = $this->getAllManagedCertificates();
@@ -910,20 +961,16 @@ class Certman implements BMO {
 	}
 
 	/**
-	 * Install a CA certificate into the system trust store.
-	 *
-	 * Validates the supplied PEM, stages it in the module's ca-staging directory
-	 * and triggers the privileged "install-ca" hook (run as root by the Sysadmin
-	 * incron runner) which copies it into the distribution trust anchors and
-	 * refreshes the trust store. When already running as root (e.g. fwconsole)
-	 * the hook is executed directly. Installation is confirmed by re-scanning the
-	 * trust store for the certificate fingerprint.
+	 * Step 1 - Load a CA certificate into Certman (does NOT touch the system trust
+	 * store). Validates the PEM and stores it as managed desired-state in the
+	 * KVStore. Installing/uninstalling it into the OS is a separate action
+	 * (setSystemCAInstall()), so the operator decides when it becomes trusted.
 	 *
 	 * @param  string $pem          PEM encoded CA certificate
 	 * @param  string $friendlyName Optional friendly name used for the stored filename
-	 * @return array  array('status' => bool, 'message' => string[, 'warning' => string])
+	 * @return array  array('status'=>bool, 'message'=>string[, 'fp'=>string, 'warning'=>string])
 	 */
-	public function installSystemCA($pem, $friendlyName = '') {
+	public function saveSystemCA($pem, $friendlyName = '') {
 		$pem = trim((string)$pem);
 		if ($pem === '') {
 			return array('status' => false, 'message' => _('No certificate data provided'));
@@ -931,7 +978,7 @@ class Certman implements BMO {
 		if (strlen($pem) > 100000) {
 			return array('status' => false, 'message' => _('The supplied certificate data is too large.'));
 		}
-		// Never accept a private key here - we only install public CA certificates.
+		// Never accept a private key here - we only handle public CA certificates.
 		if (stripos($pem, 'PRIVATE KEY') !== false) {
 			return array('status' => false, 'message' => _('The supplied data contains a private key; provide only the CA certificate.'));
 		}
@@ -961,70 +1008,277 @@ class Certman implements BMO {
 		$fpShort = $fp ? substr(preg_replace('/[^a-f0-9]/i', '', $fp), 0, 12) : '';
 		$base = 'certman-' . $name . ($fpShort !== '' ? '-' . $fpShort : '');
 
-		// Stage the PEM where the root hook can read it.
-		$staging = __DIR__ . '/ca-staging';
-		if (!is_dir($staging) && !@mkdir($staging, 0775, true)) {
-			return array('status' => false, 'message' => sprintf(_('Unable to create staging directory %s'), $staging));
+		// Preserve the install flag if this CA is being re-uploaded.
+		$existing = $this->getConfig($fp, 'systemcas');
+		$install  = (is_array($existing) && !empty($existing['install']));
+
+		// Persist as desired state in the KVStore (single source of truth: survives
+		// reboots, trust-store wipes and is included in the module backup). Large
+		// values are transparently stored as blobs by DB_Helper, so a PEM fits.
+		$this->setConfig($fp, array(
+			'pem'      => $pem,
+			'cn'       => (string)$rawCn,
+			'friendly' => (string)$friendlyName,
+			'base'     => $base,
+			'isca'     => $isCa,
+			'install'  => $install,
+			'added'    => time(),
+		), 'systemcas');
+		dbug("saveSystemCA: stored CA fp=$fp base=$base install=" . ($install ? '1' : '0'));
+
+		$result = array(
+			'status'  => true,
+			'fp'      => $fp,
+			'message' => sprintf(_('CA "%s" was loaded. Use "Install" to add it to the system trust store.'), $cn),
+		);
+		if (!$isCa) {
+			$result['warning'] = _('Note: this certificate is not marked as a CA (basicConstraints CA:TRUE).');
 		}
-		// Clean slate: drop any leftover staged files so the root hook only ever
-		// processes the certificate we are about to write.
-		foreach ((array)glob($staging . '/*.{crt,result}', GLOB_BRACE) as $stale) {
-			@unlink($stale);
-		}
-		$crtFile = $staging . '/' . $base . '.crt';
-		$resultFile = $staging . '/' . $base . '.result';
-		if (@file_put_contents($crtFile, $pem . "\n") === false) {
-			return array('status' => false, 'message' => _('Unable to stage the certificate for installation'));
+		return $result;
+	}
+
+	/**
+	 * Step 2 - Install ($install=true) or uninstall ($install=false) a managed CA
+	 * from the system trust store. Flips the desired 'install' flag in the KVStore
+	 * and runs the privileged reconcile (inline as root, else via the incron hook).
+	 *
+	 * @param  string $fp      SHA1 fingerprint of a managed CA
+	 * @param  bool   $install true to install, false to uninstall
+	 * @return array  array('status'=>bool, 'message'=>string[, 'warning'=>string])
+	 */
+	public function setSystemCAInstall($fp, $install) {
+		$fp = strtolower(preg_replace('/[^a-f0-9]/i', '', (string)$fp));
+		if ($fp === '') { return array('status' => false, 'message' => _('Invalid fingerprint')); }
+		$rec = $this->getConfig($fp, 'systemcas');
+		if (!is_array($rec)) { return array('status' => false, 'message' => _('That CA is not managed by Certman.')); }
+
+		$rec['install'] = (bool)$install;
+		$this->setConfig($fp, $rec, 'systemcas');
+		$cn = htmlspecialchars($rec['cn'] ?? $fp, ENT_QUOTES);
+		dbug("setSystemCAInstall: fp=$fp install=" . ($install ? '1' : '0'));
+
+		$target = strtoupper(implode(':', str_split($fp, 2)));
+		$err = $this->triggerReconcile(function () use ($target, $install) {
+			return $install ? $this->systemHasFingerprint($target) : !$this->systemHasFingerprint($target);
+		});
+		$present = $this->systemHasFingerprint($target);
+
+		if ($install) {
+			if ($present) {
+				$r = array('status' => true, 'message' => sprintf(_('CA "%s" was installed into the system trust store.'), $cn));
+				if (empty($rec['isca'])) { $r['warning'] = _('Note: this certificate is not marked as a CA (basicConstraints CA:TRUE).'); }
+				return $r;
+			}
+			return array('status' => true,
+				'message' => sprintf(_('CA "%s" was marked for installation.'), $cn),
+				'warning' => $err !== '' ? $err : _('It is not present in the system trust store yet; it will be installed on the next reconcile. Ensure the Sysadmin module and incrond are available.'));
 		}
 
-		// Run the privileged install.
+		if (!$present) {
+			return array('status' => true, 'message' => sprintf(_('CA "%s" was uninstalled from the system trust store.'), $cn));
+		}
+		return array('status' => true,
+			'message' => sprintf(_('CA "%s" was marked for uninstall.'), $cn),
+			'warning' => $err !== '' ? $err : _('It is still present in the system trust store; it will be removed on the next reconcile.'));
+	}
+
+	/**
+	 * One-shot install (CLI / API back-compat): load a CA and install it in a
+	 * single call. Equivalent to saveSystemCA() followed by setSystemCAInstall(true).
+	 *
+	 * @param  string $pem          PEM encoded CA certificate
+	 * @param  string $friendlyName Optional friendly name
+	 * @return array  array('status'=>bool, 'message'=>string[, 'warning'=>string])
+	 */
+	public function installSystemCA($pem, $friendlyName = '') {
+		$res = $this->saveSystemCA($pem, $friendlyName);
+		if (empty($res['status'])) { return $res; }
+		return $this->setSystemCAInstall($res['fp'], true);
+	}
+
+	/**
+	 * Run the privileged reconcile (inline when already root, otherwise via the
+	 * Sysadmin incron hook). Optionally polls a condition (for the async hook
+	 * path). Returns '' on success, or a human-readable error message.
+	 *
+	 * @param  callable|null $waitFor returns true once the desired state is reached
+	 * @return string
+	 */
+	private function triggerReconcile($waitFor = null) {
 		try {
 			if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
-				// Already root (e.g. fwconsole) - run the hook directly, restricted to our file.
-				exec(escapeshellarg(__DIR__ . '/hooks/install-ca') . ' ' . escapeshellarg($base . '.crt') . ' 2>&1');
+				$this->reconcileSystemCAs();
 			} else {
+				// The hook runs "fwconsole certificates --reconcile-system-cas" as
+				// root; no data travels through incron (it all lives in the KVStore).
 				$this->runHook('install-ca');
-				// incron is asynchronous; wait for the hook to drop its result file.
-				$waited = 0;
-				while (!file_exists($resultFile) && $waited < 20) {
-					usleep(500000);
-					$waited++;
+				if (is_callable($waitFor)) {
+					$waited = 0;
+					while ($waited < 20 && !$waitFor()) { usleep(500000); $waited++; }
+					dbug("triggerReconcile: waited " . ($waited * 0.5) . "s");
 				}
 			}
+			return '';
 		} catch (\Exception $e) {
-			@unlink($crtFile);
-			return array('status' => false, 'message' => sprintf(_('Unable to run the privileged install hook: %s. The Sysadmin module is required to install CAs into the system trust store from the web interface.'), $e->getMessage()));
+			dbug("triggerReconcile: " . $e->getMessage());
+			return sprintf(_('The privileged reconcile could not run now (%s). Ensure the Sysadmin module is installed and incrond is running.'), $e->getMessage());
+		}
+	}
+
+	/**
+	 * The CA certificates Certman manages (desired state), keyed by SHA1
+	 * fingerprint, as stored by installSystemCA() in the KVStore.
+	 *
+	 * @return array array(fpLower => array('pem','cn','friendly','base','isca','added'))
+	 */
+	public function getManagedSystemCAs() {
+		$out = array();
+		foreach ((array)$this->getAll('systemcas') as $fp => $rec) {
+			if (is_array($rec)) { $out[$fp] = $rec; }
+		}
+		return $out;
+	}
+
+	/**
+	 * True if a certificate with the given colon-separated uppercase SHA1
+	 * fingerprint is present in the system trust store right now.
+	 */
+	public function systemHasFingerprint($target) {
+		$sys = $this->getSystemCAs();
+		foreach ($sys['cas'] as $c) {
+			if (!empty($c['fingerprint']) && $c['fingerprint'] === $target) { return true; }
+		}
+		return false;
+	}
+
+	/**
+	 * Reconcile the OS trust store with the managed (KVStore) desired state:
+	 * install every managed CA that is not already present, then refresh the
+	 * trust store once. MUST run as root (called by the install-ca hook or by
+	 * "fwconsole certificates --reconcile-system-cas"). Idempotent.
+	 *
+	 * @return array array('mode','dest','installed'[],'skipped'[],'errors'[])
+	 */
+	public function reconcileSystemCAs() {
+		$managed = $this->getManagedSystemCAs();
+		list($mode, $dest) = $this->trustStoreTarget();
+
+		// Snapshot what is already trusted once (getSystemCAs re-parses every store).
+		$present = array();
+		$sys = $this->getSystemCAs();
+		foreach ($sys['cas'] as $c) {
+			if (!empty($c['fingerprint'])) { $present[$c['fingerprint']] = true; }
 		}
 
-		$hookResult = file_exists($resultFile) ? trim((string)@file_get_contents($resultFile)) : '';
-		@unlink($resultFile);
-		@unlink($crtFile); // the hook removes it on success; clean up just in case
+		$installed = array();
+		$skipped   = array();
+		$removed   = array();
+		$errors    = array();
+		$changed   = false;
 
-		// The hook is authoritative: it reports "OK" only after update-ca-* actually
-		// succeeded (and rolls the anchor back otherwise).
-		$hookOk = ($hookResult !== '' && stripos($hookResult, 'OK') === 0);
+		// 1) Install every CA marked for install that is not already trusted, and
+		//    build the set of anchor filenames we expect to own afterwards. CAs that
+		//    are managed but NOT marked for install are intentionally excluded, so
+		//    their anchors (if any) are removed as orphans in step 2.
+		$expected = array();
+		foreach ($managed as $fp => $rec) {
+			if (empty($rec['install'])) { continue; } // loaded but not installed
+			$base = !empty($rec['base']) ? preg_replace('/[^A-Za-z0-9._-]+/', '_', $rec['base']) : ('certman-' . $fp);
+			$expected[$base . '.crt'] = true;
 
-		// Only when the hook left no result (e.g. it ran fully out-of-band) do we
-		// fall back to confirming the certificate is present in the trust store.
-		$installed = $hookOk;
-		if (!$installed && $hookResult === '' && $fp) {
 			$target = strtoupper(implode(':', str_split($fp, 2)));
-			$sys = $this->getSystemCAs();
-			foreach ($sys['cas'] as $c) {
-				if (!empty($c['fingerprint']) && $c['fingerprint'] === $target) { $installed = true; break; }
+			if (isset($present[$target])) { $skipped[] = $fp; continue; }
+			if ($mode === 'none') { $errors[] = "$fp: no supported system trust store"; continue; }
+
+			$pem = isset($rec['pem']) ? (string)$rec['pem'] : '';
+			if (empty($pem) || !@openssl_x509_parse($pem)) { $errors[] = "$fp: invalid stored PEM"; continue; }
+
+			$anchor = rtrim($dest, '/') . '/' . $base . '.crt';
+			if (@file_put_contents($anchor, $pem . "\n") === false) {
+				$errors[] = "$fp: could not write $anchor (need root / disk space?)";
+				continue;
+			}
+			@chmod($anchor, 0644);
+			$installed[] = $fp;
+			$changed = true;
+		}
+
+		// 2) Remove orphaned anchors: any certman-* anchor no longer in the desired
+		//    state (i.e. the operator uninstalled it). We only ever touch our own
+		//    "certman-" prefixed files, never the distribution's CAs.
+		if ($mode !== 'none') {
+			foreach ((array)glob(rtrim($dest, '/') . '/certman-*.crt') as $anchor) {
+				if (isset($expected[basename($anchor)])) { continue; }
+				if (@unlink($anchor)) { $removed[] = basename($anchor); $changed = true; }
+				else { $errors[] = "could not remove orphan anchor " . basename($anchor) . " (need root?)"; }
 			}
 		}
 
-		if ($installed) {
-			$result = array('status' => true, 'message' => sprintf(_('CA "%s" was installed into the system trust store.'), $cn));
-			if (!$isCa) {
-				$result['warning'] = _('Note: this certificate is not marked as a CA (basicConstraints CA:TRUE).');
+		if ($changed && $mode !== 'none') {
+			if (!$this->refreshTrustStore($mode)) {
+				$errors[] = "trust store refresh ($mode) failed";
 			}
-			return $result;
 		}
 
-		$detail = $hookResult !== '' ? htmlspecialchars($hookResult, ENT_QUOTES) : _('the certificate was staged but could not be confirmed in the system trust store. Ensure the Sysadmin module is installed and up to date.');
-		return array('status' => false, 'message' => sprintf(_('Could not confirm installation of CA "%s": %s'), $cn, $detail));
+		$sum = array('mode' => $mode, 'dest' => $dest, 'installed' => $installed, 'skipped' => $skipped, 'removed' => $removed, 'errors' => $errors);
+		dbug("reconcileSystemCAs: " . json_encode($sum));
+		return $sum;
+	}
+
+	/**
+	 * Uninstall a managed CA: drop it from the desired state (KVStore) and trigger
+	 * the privileged reconcile, which removes the orphaned trust anchor as root and
+	 * refreshes the store. The KVStore removal always works; the anchor removal
+	 * happens via the root reconcile (inline when already root, else via the hook).
+	 * Returns true if the CA was managed and has been scheduled for removal.
+	 */
+	public function removeManagedSystemCA($fp) {
+		$fp = strtolower(preg_replace('/[^a-f0-9]/i', '', (string)$fp));
+		if ($fp === '') { return false; }
+		$managed = $this->getManagedSystemCAs();
+		if (!isset($managed[$fp])) { return false; }
+
+		// Drop from desired state; the privileged reconcile removes the anchor.
+		$rec = $managed[$fp];
+		$base = !empty($rec['base']) ? preg_replace('/[^A-Za-z0-9._-]+/', '_', $rec['base']) : ('certman-' . $fp);
+		$this->delConfig($fp, 'systemcas');
+		dbug("removeManagedSystemCA: dropped $fp from KVStore; triggering reconcile");
+		list($mode, $dest) = $this->trustStoreTarget();
+		$anchorGone = function () use ($mode, $dest, $base) {
+			return $mode === 'none' || !is_file(rtrim($dest, '/') . '/' . $base . '.crt');
+		};
+		$this->triggerReconcile($anchorGone);
+		return true;
+	}
+
+	/**
+	 * Pick the distribution trust mechanism. Returns array($mode, $destDir) where
+	 * $mode is 'rhel', 'debian' or 'none'.
+	 */
+	private function trustStoreTarget() {
+		if ($this->haveCmd('update-ca-trust') && is_dir('/etc/pki/ca-trust/source/anchors')) {
+			return array('rhel', '/etc/pki/ca-trust/source/anchors');
+		}
+		if ($this->haveCmd('update-ca-certificates') && is_dir('/usr/local/share/ca-certificates')) {
+			return array('debian', '/usr/local/share/ca-certificates');
+		}
+		return array('none', '');
+	}
+
+	private function haveCmd($cmd) {
+		$out = array(); $rc = 1;
+		@exec('command -v ' . escapeshellarg($cmd) . ' 2>/dev/null', $out, $rc);
+		return $rc === 0;
+	}
+
+	private function refreshTrustStore($mode) {
+		$out = array(); $rc = 1;
+		if ($mode === 'rhel') {
+			@exec('update-ca-trust extract 2>&1', $out, $rc);
+		} else {
+			@exec('update-ca-certificates 2>&1', $out, $rc);
+		}
+		return $rc === 0;
 	}
 
 	/**
@@ -1366,6 +1620,15 @@ class Certman implements BMO {
 	 * FreePBX chown hooks
 	 */
 	public function chownFreepbx() {
+		$files = array();
+		// The privileged hooks under hooks/ are executed AS ROOT by the Sysadmin
+		// incron runner, which only runs a hook when it carries the right ownership
+		// and executable bit. Register the directory so 'fwconsole chown' fixes the
+		// permissions of every hook (including newly added ones such as install-ca);
+		// without this the trigger is consumed by incron but the hook never runs.
+		$files[] = array('type' => 'execdir',
+				'path' => __DIR__ . "/hooks",
+				'perms' => 0755);
 		$certs = $this->getAllManagedCertificates();
 		$location = $this->PKCS->getKeysLocation();
 		$files[] = array('type' => 'rdir',
@@ -2320,6 +2583,10 @@ class Certman implements BMO {
 		switch ($req) {
 			case 'makeDefault':
 			case 'getJSON':
+			case 'getManagedCAsGrid':
+			case 'getSystemCAsGrid':
+			case 'generateLEStart':
+			case 'generateLEStatus':
 				return true;
 			break;
 		}
@@ -2333,7 +2600,180 @@ class Certman implements BMO {
 		if('getJSON' == $_REQUEST['command'] && 'grid' == $_REQUEST['jdata']){
 			return $this->getAllManagedCertificates();
 		}
+		// bootstrap-table data-url grids for the "Installed CAs" page.
+		if('getManagedCAsGrid' == $_REQUEST['command']){
+			return $this->buildManagedCAsGrid();
+		}
+		if('getSystemCAsGrid' == $_REQUEST['command']){
+			return $this->buildSystemCAsGrid();
+		}
+		// Background Let's Encrypt generation (launch + status polling).
+		if('generateLEStart' == $_REQUEST['command']){
+			return $this->startLEGeneration($_POST);
+		}
+		if('generateLEStatus' == $_REQUEST['command']){
+			return $this->getLEGenerationStatus($_REQUEST['host'] ?? '');
+		}
 		return false;
+	}
+
+	/**
+	 * Paths of the log / done-marker files for a background LE generation job.
+	 * They live in the Asterisk spool tmp directory (writable by the web user).
+	 */
+	private function leGenFiles($host) {
+		$safe  = preg_replace('/[^a-z0-9._-]+/i', '_', basename(strtolower((string)$host)));
+		$spool = $this->FreePBX->Config->get('ASTSPOOLDIR');
+		if (empty($spool)) { $spool = '/var/spool/asterisk'; }
+		$dir = rtrim($spool, '/') . '/tmp';
+		return array(
+			'safe' => $safe,
+			'dir'  => $dir,
+			'log'  => $dir . '/certman-legen-' . $safe . '.log',
+			'done' => $dir . '/certman-legen-' . $safe . '.done',
+		);
+	}
+
+	/**
+	 * Launch a Let's Encrypt certificate generation in the background and return
+	 * immediately. The actual work runs as a detached "fwconsole certificates
+	 * --generate --type=le ..." process whose output is captured to a per-host log
+	 * file; an exit-code marker file signals completion. The web side polls
+	 * getLEGenerationStatus() to follow progress. Mirrors the synchronous add flow.
+	 *
+	 * @param  array $p POST data from the LE form
+	 * @return array array('status'=>bool, 'host'=>string[, 'message'=>string])
+	 */
+	public function startLEGeneration($p) {
+		$host  = isset($p['host'])  ? basename(strtolower(trim($p['host']))) : '';
+		// Editing an existing certificate: the host is shown as text (not an input),
+		// so it is not in the form - resolve it from the certificate id.
+		if ($host === '' && !empty($p['cid'])) {
+			$cd = $this->getCertificateDetails($p['cid']);
+			if (!empty($cd['basename'])) { $host = basename(strtolower($cd['basename'])); }
+		}
+		$email = isset($p['email']) ? trim($p['email']) : '';
+		$C     = isset($p['C'])     ? trim($p['C']) : '';
+		$ST    = isset($p['ST'])    ? trim($p['ST']) : '';
+		$acmeUrlEarly = !empty($p['acme_url']) ? trim($p['acme_url']) : '';
+		// Host is always required. The public Let's Encrypt service also needs country
+		// and email; a private ACME server (custom URL) only needs the host.
+		if ($host === '') {
+			return array('status' => false, 'message' => _('Host name is required.'));
+		}
+		if ($acmeUrlEarly === '' && ($email === '' || $C === '')) {
+			return array('status' => false, 'message' => _('Country and email are required for the public Let\'s Encrypt service.'));
+		}
+		// New certificate: refuse if one already exists (matches the add handler).
+		if (empty($p['cid']) && $this->checkCertificateName($host)) {
+			return array('status' => false, 'message' => sprintf(_('%s already exists!'), $host));
+		}
+
+		$san = array();
+		if (!empty($p['SAN'])) {
+			$san = array_unique(array_filter(array_map('trim', explode("\n", strtolower($p['SAN'])))));
+		}
+		$acmeUrl      = $acmeUrlEarly;
+		$acmeCaBundle = !empty($p['acme_ca'])  ? trim($p['acme_ca'])  : '';
+		$acmeInsecure = !empty($p['acme_insecure']);
+
+		$f = $this->leGenFiles($host);
+		if (!is_dir($f['dir'])) { @mkdir($f['dir'], 0775, true); }
+		@unlink($f['done']);
+		@unlink($f['log']);
+
+		$fwconsole = rtrim((string)($this->FreePBX->Config->get('AMPSBIN') ?: '/usr/sbin'), '/') . '/fwconsole';
+		$cmd = escapeshellarg($fwconsole) . ' certificates --generate --type=le'
+			. ' --hostname=' . escapeshellarg($host)
+			. ' --force';
+		// Optional fields - only pass them when provided; the CLI/updateLE default them.
+		if ($C !== '')     { $cmd .= ' --country-code=' . escapeshellarg($C); }
+		if ($ST !== '')    { $cmd .= ' --state=' . escapeshellarg($ST); }
+		if ($email !== '') { $cmd .= ' --email=' . escapeshellarg($email); }
+		foreach ($san as $s) { $cmd .= ' --san=' . escapeshellarg($s); }
+		if ($acmeUrl !== '') {
+			$cmd .= ' --acme-url=' . escapeshellarg($acmeUrl);
+			if ($acmeCaBundle !== '') { $cmd .= ' --acme-ca=' . escapeshellarg($acmeCaBundle); }
+			if ($acmeInsecure) { $cmd .= ' --acme-insecure'; }
+		}
+
+		// Run detached: capture output to the log, then write the exit code marker.
+		$script = $cmd . ' > ' . escapeshellarg($f['log']) . ' 2>&1; echo $? > ' . escapeshellarg($f['done']);
+		$full = 'nohup bash -c ' . escapeshellarg($script) . ' >/dev/null 2>&1 &';
+		exec($full);
+		dbug("startLEGeneration: launched background generation for $host");
+
+		return array('status' => true, 'host' => $host);
+	}
+
+	/**
+	 * Read the status of a background LE generation job started by
+	 * startLEGeneration(). Returns the captured log plus running/finished/success.
+	 *
+	 * @param  string $host
+	 * @return array
+	 */
+	public function getLEGenerationStatus($host) {
+		$f = $this->leGenFiles($host);
+		$log      = is_file($f['log'])  ? (string)@file_get_contents($f['log']) : '';
+		$finished = is_file($f['done']);
+		$success  = false;
+		if ($finished) {
+			$success = (trim((string)@file_get_contents($f['done'])) === '0');
+		}
+		return array(
+			'status'   => true,
+			'running'  => !$finished,
+			'finished' => $finished,
+			'success'  => $success,
+			'log'      => $log,
+		);
+	}
+
+	/**
+	 * Raw rows for the "CAs Loaded into Certman" bootstrap-table (AJAX data-url).
+	 * The view renders these with JS data-formatter functions.
+	 */
+	private function buildManagedCAsGrid() {
+		$sys = $this->getSystemCAs();
+		$present = array();
+		foreach ($sys['cas'] as $c) {
+			if (!empty($c['fingerprint'])) { $present[$c['fingerprint']] = true; }
+		}
+		$rows = array();
+		foreach ($this->getManagedSystemCAs() as $fp => $rec) {
+			$target = strtoupper(implode(':', str_split($fp, 2)));
+			$rows[] = array(
+				'cn'          => (string)($rec['cn'] ?? ($rec['friendly'] ?? $fp)),
+				'fingerprint' => $target,
+				'wantInstall' => !empty($rec['install']),
+				'present'     => isset($present[$target]),
+				'fp'          => $fp,
+			);
+		}
+		return $rows;
+	}
+
+	/**
+	 * Raw rows for the "Trusted CA Certificates" bootstrap-table (AJAX data-url).
+	 */
+	private function buildSystemCAsGrid() {
+		$sys = $this->getSystemCAs();
+		$now = time();
+		$rows = array();
+		foreach ($sys['cas'] as $ca) {
+			$rows[] = array(
+				'cn'          => (string)$ca['cn'],
+				'subject'     => (string)$ca['subject'],
+				'issuer'      => (string)$ca['issuer'],
+				'selfSigned'  => !empty($ca['selfSigned']),
+				'expires'     => !empty($ca['validTo_time_t']) ? date('Y-m-d', $ca['validTo_time_t']) : '-',
+				'expired'     => (!empty($ca['validTo_time_t']) && $ca['validTo_time_t'] < $now),
+				'fingerprint' => (string)$ca['fingerprint'],
+				'source'      => (string)$ca['source'],
+			);
+		}
+		return $rows;
 	}
 
 	/**
@@ -2456,9 +2896,13 @@ class Certman implements BMO {
 
 
 	public function runHook($hookname, $params = false) {
-		// Runs a new style Syadmin hook
+		// Runs a new style Sysadmin hook (executed as root by the incron runner).
+		// Mirrors the proven mechanism used by other working modules: it throws on
+		// every failure (so the caller sees a real error instead of a silent false)
+		// and supports passing params inside the trigger file (.CONTENTS) on modern
+		// sysadmin RPMs, falling back to the legacy filename-param scheme otherwise.
 		if (!file_exists("/etc/incron.d/sysadmin")) {
-			throw new \Exception("Sysadmin RPM not up to date");
+			throw new \Exception("Sysadmin RPM not up to date, or not a known OS.");
 		}
 
 		$basedir = "/var/spool/asterisk/incron";
@@ -2473,41 +2917,61 @@ class Certman implements BMO {
 
 		// Cool. So I want to run this hook..
 		$filename = "$basedir/certman.$hookname";
+		if (file_exists($filename)) {
+			throw new \Exception("Hook $hookname is already running");
+		}
 
-		// Do I have any params?
+		// On a modern sysadmin RPM we can put the params INSIDE the trigger file
+		// (no filename length limit); otherwise they go into the filename.
+		$max = false;
+		if (file_exists("/etc/sysadmin_contents_max")) {
+			$fh = fopen("/etc/sysadmin_contents_max", "r");
+			if ($fh) { $max = (int) fgets($fh); fclose($fh); }
+		}
+		if ($max > 65535 || $max < 128) { $max = false; }
+
+		$contents = "";
 		if ($params) {
-			// Oh. I do. If it's an array, json encode and base64
 			if (is_array($params)) {
 				$b = base64_encode(gzcompress(json_encode($params)));
-				// Note we derp the base64, changing / to _, because filepath.
-				$filename .= ".".str_replace('/', '_', $b);
+				if ($max) {
+					if (strlen($b) > $max) {
+						throw new \Exception("Contents too big for current sysadmin-rpm. This is possibly a bug!");
+					}
+					$contents = $b;
+					$filename .= ".CONTENTS";
+				} else {
+					// Legacy scheme: base64 in the filename, '/' derped to '_'.
+					$filename .= ".".str_replace('/', '_', $b);
+					if (strlen($filename) > 200) {
+						throw new \Exception("Too much data, and old sysadmin rpm. Please run 'yum update'");
+					}
+				}
+			} elseif (is_object($params)) {
+				throw new \Exception("Can't pass objects to hooks");
 			} else {
-				// Cast it to a string if it's anything else, and then make sure
-				// it doesn't have any spaces.
+				// Cast to string and strip blanks so it's filename-safe.
 				$filename .= ".".preg_replace("/[[:blank:]]+/", "", (string) $params);
 			}
 		}
 
-		// Make sure it doesn't exist, if it was left hanging around
-		// for some reason
-		@unlink($filename);
-
 		$fh = fopen($filename, "w+");
 		if ($fh === false) {
-			// WTF, unable to create file?
-			return false;
+			throw new \Exception("Unable to create hook trigger '$filename'");
 		}
-
-		// Now incron does its thing.
+		fwrite($fh, $contents);
+		// As soon as we close it, incron does its thing.
 		fclose($fh);
 
-		// Wait .5 of a second, make sure it's been deleted.
-		usleep(500000);
-		if (!file_exists($filename)) {
-			return true;
+		// Wait up to 10 seconds for incron to consume (delete) the trigger.
+		$maxloops = 20;
+		while ($maxloops--) {
+			if (!file_exists($filename)) {
+				return true;
+			}
+			usleep(500000);
 		}
-		// Odd. It should be gone. Something went wrong.
-		return false;
+		throw new \Exception("Hook file '$filename' was not picked up by Incron after 10 seconds. Is incrond running?");
 	}
 
 	function addAutoUpdateCron() {

--- a/Console/Certman.class.php
+++ b/Console/Certman.class.php
@@ -30,6 +30,7 @@ class Certman extends Command {
 				new InputOption('updateall', null, InputOption::VALUE_NONE, _('Check and Update all Certificates')),
 				new InputOption('force', null, InputOption::VALUE_NONE, _('Force update, by pass 30 days expiry ')),
 				new InputOption('import', null, InputOption::VALUE_NONE, sprintf(_('Import any unmanaged certificates in %s'),$loc)),
+				new InputOption('install-ca', null, InputOption::VALUE_REQUIRED, _('Install a CA certificate (path to a PEM file) into the system trust store')),
 
 				// cert generation options
 				new InputOption('generate', null, InputOption::VALUE_NONE, _('Generate Certificate')),
@@ -39,6 +40,9 @@ class Certman extends Command {
 				new InputOption('state', null, InputOption::VALUE_REQUIRED, _('State/Provence/Region (LetsEncrypt Generation)')),
 				new InputOption('email', null, InputOption::VALUE_REQUIRED, _("Owner's email (LetsEncrypt Generation)")),
 				new InputOption('san', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, _("Certificate Subject Alternative Name(s) (LetsEncrypt Generation)")),
+				new InputOption('acme-url', null, InputOption::VALUE_REQUIRED, _('Custom ACME directory URL for a private/self-hosted Let\'s Encrypt server (LetsEncrypt Generation). Empty uses the public service')),
+				new InputOption('acme-ca', null, InputOption::VALUE_REQUIRED, _('Path to the CA bundle that signed the custom ACME server certificate (LetsEncrypt Generation)')),
+				new InputOption('acme-insecure', null, InputOption::VALUE_NONE, _('Skip TLS verification of the custom ACME server (LetsEncrypt Generation)')),
 
 				new InputOption('delete', null, InputOption::VALUE_REQUIRED, _('Delete certificate by id or hostname')),
 				new InputOption('default', null, InputOption::VALUE_REQUIRED, _('Set default certificate by id or hostname')),
@@ -49,6 +53,23 @@ class Certman extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output){
 		$certman = \FreePBX::create()->Certman;
 		$pkcs = \FreePBX::create()->PKCS;
+
+		if($installCa = $input->getOption('install-ca')) {
+			if(!is_file($installCa)) {
+				$output->writeln("<error>".sprintf(_("File not found: %s"), $installCa)."</error>");
+				exit(4);
+			}
+			$pem = file_get_contents($installCa);
+			$res = $certman->installSystemCA($pem, basename($installCa));
+			if(!empty($res['status'])) {
+				$msg = $res['message'];
+				if(!empty($res['warning'])) { $msg .= ' ' . $res['warning']; }
+				$output->writeln("<info>".$msg."</info>");
+				return 0;
+			}
+			$output->writeln("<error>".$res['message']."</error>");
+			exit(4);
+		}
 
 		if($input->getOption('generate')) {
 			$type = $input->getOption('type');
@@ -66,6 +87,9 @@ class Certman extends Command {
 					$description = $hostname;
 					$san = array_unique(array_filter(array_map(function ($v) {return strtolower(trim($v));}, $input->getOption('san'))));
 					$force = $input->getOption('force');
+					$acmeUrl = trim((string)$input->getOption('acme-url'));
+					$acmeCaBundle = trim((string)$input->getOption('acme-ca'));
+					$acmeInsecure = (bool)$input->getOption('acme-insecure');
 					$cert = $certman->getCertificateDetailsByBasename($hostname);
 
 					if (!($hostname && $country_code && $state && $email)) {
@@ -88,6 +112,11 @@ class Certman extends Command {
 						"removeDstRootCaX3" => false,
 					);
 					if (!empty($san)) {$additional['san'] = $san;}
+					if ($acmeUrl !== '') {
+						$additional['acmeUrl'] = $acmeUrl;
+						$additional['acmeCaBundle'] = $acmeCaBundle;
+						$additional['acmeInsecure'] = $acmeInsecure;
+					}
 
 					if ($force) {
 						$output->writeln("<info>" . _("Forced update enabled !!!") . "</info>");
@@ -110,6 +139,9 @@ class Certman extends Command {
 							"email" => $email,
 							"san" => $san,
 							"removeDstRootCaX3" => false,
+							"acmeUrl" => $acmeUrl,
+							"acmeCaBundle" => $acmeCaBundle,
+							"acmeInsecure" => $acmeInsecure,
 						);
 
 						$le_result = $certman->updateLE($hostname, $settings, false, $force);

--- a/Console/Certman.class.php
+++ b/Console/Certman.class.php
@@ -31,6 +31,7 @@ class Certman extends Command {
 				new InputOption('force', null, InputOption::VALUE_NONE, _('Force update, by pass 30 days expiry ')),
 				new InputOption('import', null, InputOption::VALUE_NONE, sprintf(_('Import any unmanaged certificates in %s'),$loc)),
 				new InputOption('install-ca', null, InputOption::VALUE_REQUIRED, _('Install a CA certificate (path to a PEM file) into the system trust store')),
+				new InputOption('reconcile-system-cas', null, InputOption::VALUE_NONE, _('Install any managed CA certificates that are missing from the system trust store (run as root)')),
 
 				// cert generation options
 				new InputOption('generate', null, InputOption::VALUE_NONE, _('Generate Certificate')),
@@ -71,6 +72,21 @@ class Certman extends Command {
 			exit(4);
 		}
 
+		if($input->getOption('reconcile-system-cas')) {
+			$sum = $certman->reconcileSystemCAs();
+			if(!empty($input->getOption('json'))) {
+				$output->writeln(json_encode($sum));
+				return 0;
+			}
+			$output->writeln(sprintf(_("Trust store: %s"), $sum['mode'] === 'none' ? _('none found') : $sum['mode']));
+			$output->writeln(sprintf(_("Installed: %d, removed: %d, already present: %d, errors: %d"),
+				count($sum['installed']), count($sum['removed'] ?? array()), count($sum['skipped']), count($sum['errors'])));
+			foreach($sum['errors'] as $e) {
+				$output->writeln("<error>".$e."</error>");
+			}
+			return empty($sum['errors']) ? 0 : 4;
+		}
+
 		if($input->getOption('generate')) {
 			$type = $input->getOption('type');
 			switch($type) {
@@ -92,8 +108,14 @@ class Certman extends Command {
 					$acmeInsecure = (bool)$input->getOption('acme-insecure');
 					$cert = $certman->getCertificateDetailsByBasename($hostname);
 
-					if (!($hostname && $country_code && $state && $email)) {
-						$output->writeln("<error>"._("Missing required argument(s) - 'hostname', 'country-code', 'state' and 'email' are required")."</error>");
+					if (!$hostname) {
+						$output->writeln("<error>"._("Missing required argument 'hostname'")."</error>");
+						exit(4);
+					}
+					// The public Let's Encrypt service also requires country and email;
+					// a private ACME server (--acme-url) only needs the hostname.
+					if ($acmeUrl === '' && !($country_code && $email)) {
+						$output->writeln("<error>"._("'country-code' and 'email' are required for the public Let's Encrypt service")."</error>");
 						exit(4);
 					}
 

--- a/Restore.php
+++ b/Restore.php
@@ -46,6 +46,19 @@ class Restore Extends Base\RestoreBase{
 			$dtls['certificate'] = $dtls['cid'];
 			$this->certman->addDTLSOptions($dtls['id'], $dtls);
 		}
+
+		// Restore the module KVStore (the system trust-store CAs live under id
+		// 'systemcas'), then reconcile them into the OS trust store. Reconcile needs
+		// root; when restore runs unprivileged the records are still saved and get
+		// applied by the next reconcile.
+		if (!empty($configs['kvstore']) && is_array($configs['kvstore'])) {
+			$this->importKVStore($configs['kvstore']);
+			try {
+				$this->certman->reconcileSystemCAs();
+			} catch (\Exception $e) {
+				echo $e->getMessage() . PHP_EOL;
+			}
+		}
 		return $this;
 	}
 

--- a/assets/js/certman.js
+++ b/assets/js/certman.js
@@ -112,7 +112,7 @@ $(function() {
 		var stop = false,
 				type = $("#certtype").val();
 		$("form[name=frm_certman] input[type=\"text\"]").each( function(i, v) {
-			if($(this).attr("name") == "ST" || $(this).attr("name") == "L" || $(this).attr("name") == "OU" || $(this).attr("name") == "acme_url" || $(this).attr("name") == "acme_ca") {
+			if($(this).attr("name") == "ST" || $(this).attr("name") == "L" || $(this).attr("name") == "OU" || $(this).attr("name") == "email" || $(this).attr("name") == "acme_url" || $(this).attr("name") == "acme_ca") {
 				return true;
 			}
 			if ($(this).val() === "") {
@@ -125,13 +125,23 @@ $(function() {
 			return false;
 		}
 		if(type == "le") {
-			if($("#ST").val() === "") {
-				warnInvalid($("#ST"),_("State can not be left blank!"));
-				return false;
-			}
+			// Host name is always required. For the public Let's Encrypt service
+			// country and email are required too; a private ACME server (custom URL)
+			// only needs the host (the CA uses CN/SAN and updateLE defaults the rest).
 			if($("#host").val() === "") {
 				warnInvalid($("#host"),_("Host Name can not be left blank!"));
 				return false;
+			}
+			var leIsPrivate = $.trim($("#acme_url").val()) !== "";
+			if(!leIsPrivate) {
+				if($("#email").val() === "") {
+					warnInvalid($("#email"),_("Email is required for the public Let's Encrypt service!"));
+					return false;
+				}
+				if($("#C").val() === "" || $("#C").val() === null) {
+					warnInvalid($("#C"),_("Country is required for the public Let's Encrypt service!"));
+					return false;
+				}
 			}
 		} else {
 			if($("#ST").val() === "" && $("#L").val() === "") {

--- a/assets/js/certman.js
+++ b/assets/js/certman.js
@@ -112,7 +112,7 @@ $(function() {
 		var stop = false,
 				type = $("#certtype").val();
 		$("form[name=frm_certman] input[type=\"text\"]").each( function(i, v) {
-			if($(this).attr("name") == "ST" || $(this).attr("name") == "L" || $(this).attr("name") == "OU") {
+			if($(this).attr("name") == "ST" || $(this).attr("name") == "L" || $(this).attr("name") == "OU" || $(this).attr("name") == "acme_url" || $(this).attr("name") == "acme_ca") {
 				return true;
 			}
 			if ($(this).val() === "") {

--- a/hooks/fix-le-root-ca
+++ b/hooks/fix-le-root-ca
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-trust dump --filter "pkcs11:id=%c4%a7%b1%a4%7b%2c%71%fa%db%e1%4b%90%75%ff%c4%15%60%85%89%10" | openssl x509 | sudo tee /etc/pki/ca-trust/source/blacklist/DST-Root-CA-X3.pem
-update-ca-trust extract

--- a/hooks/install-ca
+++ b/hooks/install-ca
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Certificate Manager - install CA certificate(s) into the system trust store.
+#
+# This hook is executed AS ROOT by the Sysadmin incron runner (see runHook()).
+# The web UI, running as the unprivileged web user, stages one or more PEM
+# certificates as *.crt files in the module's ca-staging directory; this hook
+# copies each into the distribution trust anchors and refreshes the trust store.
+# For every staged file it writes a <name>.result file the web side reads back,
+# then removes the staged input.
+
+MODDIR="$(cd "$(dirname "$0")/.." && pwd)"
+STAGING="$MODDIR/ca-staging"
+
+[ -d "$STAGING" ] || exit 0
+
+# Pick the distribution trust mechanism.
+if command -v update-ca-trust >/dev/null 2>&1 && [ -d /etc/pki/ca-trust/source/anchors ]; then
+	DEST="/etc/pki/ca-trust/source/anchors"
+	MODE="rhel"
+elif command -v update-ca-certificates >/dev/null 2>&1 && [ -d /usr/local/share/ca-certificates ]; then
+	DEST="/usr/local/share/ca-certificates"
+	MODE="debian"
+else
+	MODE="none"
+fi
+
+shopt -s nullglob
+for f in "$STAGING"/*.crt; do
+	base="$(basename "${f%.crt}")"
+	result="${f%.crt}.result"
+
+	if [ "$MODE" = "none" ]; then
+		echo "ERROR: no supported system trust store found (need update-ca-trust or update-ca-certificates)" > "$result"
+		rm -f "$f"
+		continue
+	fi
+
+	# Make sure it really is a certificate before trusting it.
+	if ! openssl x509 -in "$f" -noout >/dev/null 2>&1; then
+		echo "ERROR: not a valid PEM certificate" > "$result"
+		rm -f "$f"
+		continue
+	fi
+
+	if cp "$f" "$DEST/$base.crt" 2>/dev/null; then
+		chmod 0644 "$DEST/$base.crt"
+		if [ "$MODE" = "rhel" ]; then
+			update-ca-trust extract >/dev/null 2>&1
+		else
+			update-ca-certificates >/dev/null 2>&1
+		fi
+		echo "OK: installed as $DEST/$base.crt" > "$result"
+	else
+		echo "ERROR: could not write to $DEST" > "$result"
+	fi
+	rm -f "$f"
+done
+
+exit 0

--- a/hooks/install-ca
+++ b/hooks/install-ca
@@ -1,87 +1,23 @@
 #!/bin/bash
-# Certificate Manager - install CA certificate(s) into the system trust store.
+# Certificate Manager - privileged trust-store reconcile.
 #
-# This hook is executed AS ROOT by the Sysadmin incron runner (see runHook()).
-# The web UI, running as the unprivileged web user, stages a PEM certificate as a
-# *.crt file in the module's ca-staging directory; this hook copies it into the
-# distribution trust anchors and refreshes the trust store. For every staged file
-# it writes a <name>.result file the web side reads back, then removes the input.
+# Executed AS ROOT by the Sysadmin incron runner (triggered by Certman::runHook).
+# It carries no data: the CA certificates to trust live in the module's KVStore.
+# All this hook does is run, as root, the reconcile command that reads that
+# desired state and installs into the OS trust store anything still missing.
 #
-# An optional argument restricts processing to a single staged file (basename
-# only); without it, the whole directory is processed but stale files (planted
-# and left behind) are ignored as a defence-in-depth measure.
+# Output is appended to a log so failures are diagnosable (incron discards stdout).
 
-MODDIR="$(cd "$(dirname "$0")/.." && pwd)"
-STAGING="$MODDIR/ca-staging"
-TARGET="$1"
+LOG="/var/log/asterisk/certman-install-ca.log"
+[ -d /var/log/asterisk ] && [ -w /var/log/asterisk ] || LOG="/var/spool/asterisk/tmp/certman-install-ca.log"
 
-[ -d "$STAGING" ] || exit 0
+FWCONSOLE="$(command -v fwconsole 2>/dev/null)"
+[ -n "$FWCONSOLE" ] || FWCONSOLE="/usr/sbin/fwconsole"
 
-# Pick the distribution trust mechanism.
-if command -v update-ca-trust >/dev/null 2>&1 && [ -d /etc/pki/ca-trust/source/anchors ]; then
-	DEST="/etc/pki/ca-trust/source/anchors"
-	MODE="rhel"
-elif command -v update-ca-certificates >/dev/null 2>&1 && [ -d /usr/local/share/ca-certificates ]; then
-	DEST="/usr/local/share/ca-certificates"
-	MODE="debian"
-else
-	MODE="none"
-fi
-
-# Determine which staged files to process.
-if [ -n "$TARGET" ]; then
-	# basename() ensures the argument can never escape the staging directory.
-	files=("$STAGING/$(basename "$TARGET")")
-else
-	shopt -s nullglob
-	files=("$STAGING"/*.crt)
-fi
-
-for f in "${files[@]}"; do
-	[ -f "$f" ] || continue
-	[[ "$f" == *.crt ]] || continue
-	base="$(basename "${f%.crt}")"
-	result="${f%.crt}.result"
-
-	# Defence in depth: when processing the whole directory, ignore (and remove)
-	# stale staged files older than 5 minutes that may have been planted.
-	if [ -z "$TARGET" ] && [ -n "$(find "$f" -mmin +5 2>/dev/null)" ]; then
-		rm -f "$f"
-		continue
-	fi
-
-	if [ "$MODE" = "none" ]; then
-		echo "ERROR: no supported system trust store found (need update-ca-trust or update-ca-certificates)" > "$result"
-		rm -f "$f"
-		continue
-	fi
-
-	# Make sure it really is a certificate before trusting it.
-	if ! openssl x509 -in "$f" -noout >/dev/null 2>&1; then
-		echo "ERROR: not a valid PEM certificate" > "$result"
-		rm -f "$f"
-		continue
-	fi
-
-	if cp "$f" "$DEST/$base.crt" 2>/dev/null; then
-		chmod 0644 "$DEST/$base.crt"
-		if [ "$MODE" = "rhel" ]; then
-			update-ca-trust extract >/dev/null 2>&1
-		else
-			update-ca-certificates >/dev/null 2>&1
-		fi
-		rc=$?
-		if [ "$rc" -eq 0 ]; then
-			echo "OK: installed as $DEST/$base.crt" > "$result"
-		else
-			# Roll back so we never leave an anchor that the trust store didn't accept.
-			rm -f "$DEST/$base.crt"
-			echo "ERROR: trust store update failed (exit $rc)" > "$result"
-		fi
-	else
-		echo "ERROR: could not write to $DEST" > "$result"
-	fi
-	rm -f "$f"
-done
+{
+	echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$$] install-ca: reconcile as $(id -un) using $FWCONSOLE"
+	"$FWCONSOLE" certificates --reconcile-system-cas 2>&1
+	echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$$] install-ca: reconcile exit=$?"
+} >> "$LOG" 2>&1
 
 exit 0

--- a/hooks/install-ca
+++ b/hooks/install-ca
@@ -2,14 +2,18 @@
 # Certificate Manager - install CA certificate(s) into the system trust store.
 #
 # This hook is executed AS ROOT by the Sysadmin incron runner (see runHook()).
-# The web UI, running as the unprivileged web user, stages one or more PEM
-# certificates as *.crt files in the module's ca-staging directory; this hook
-# copies each into the distribution trust anchors and refreshes the trust store.
-# For every staged file it writes a <name>.result file the web side reads back,
-# then removes the staged input.
+# The web UI, running as the unprivileged web user, stages a PEM certificate as a
+# *.crt file in the module's ca-staging directory; this hook copies it into the
+# distribution trust anchors and refreshes the trust store. For every staged file
+# it writes a <name>.result file the web side reads back, then removes the input.
+#
+# An optional argument restricts processing to a single staged file (basename
+# only); without it, the whole directory is processed but stale files (planted
+# and left behind) are ignored as a defence-in-depth measure.
 
 MODDIR="$(cd "$(dirname "$0")/.." && pwd)"
 STAGING="$MODDIR/ca-staging"
+TARGET="$1"
 
 [ -d "$STAGING" ] || exit 0
 
@@ -24,10 +28,27 @@ else
 	MODE="none"
 fi
 
-shopt -s nullglob
-for f in "$STAGING"/*.crt; do
+# Determine which staged files to process.
+if [ -n "$TARGET" ]; then
+	# basename() ensures the argument can never escape the staging directory.
+	files=("$STAGING/$(basename "$TARGET")")
+else
+	shopt -s nullglob
+	files=("$STAGING"/*.crt)
+fi
+
+for f in "${files[@]}"; do
+	[ -f "$f" ] || continue
+	[[ "$f" == *.crt ]] || continue
 	base="$(basename "${f%.crt}")"
 	result="${f%.crt}.result"
+
+	# Defence in depth: when processing the whole directory, ignore (and remove)
+	# stale staged files older than 5 minutes that may have been planted.
+	if [ -z "$TARGET" ] && [ -n "$(find "$f" -mmin +5 2>/dev/null)" ]; then
+		rm -f "$f"
+		continue
+	fi
 
 	if [ "$MODE" = "none" ]; then
 		echo "ERROR: no supported system trust store found (need update-ca-trust or update-ca-certificates)" > "$result"
@@ -49,7 +70,14 @@ for f in "$STAGING"/*.crt; do
 		else
 			update-ca-certificates >/dev/null 2>&1
 		fi
-		echo "OK: installed as $DEST/$base.crt" > "$result"
+		rc=$?
+		if [ "$rc" -eq 0 ]; then
+			echo "OK: installed as $DEST/$base.crt" > "$result"
+		else
+			# Roll back so we never leave an anchor that the trust store didn't accept.
+			rm -f "$DEST/$base.crt"
+			echo "ERROR: trust store update failed (exit $rc)" > "$result"
+		fi
 	else
 		echo "ERROR: could not write to $DEST" > "$result"
 	fi

--- a/install.php
+++ b/install.php
@@ -44,13 +44,13 @@ $set['description'] = 'Number of days before a certificate expiration for sendin
 $set['type'] = CONF_TYPE_INT;
 $freepbx_conf->define_conf_setting('CERT_DAYS_EXPIRATION_ALERT',$set,true);
 
-// Fix Let's Encrypt DST-Root-CA-X3 issue
-$m = \module_functions::create();
-$distro = $m->_distro_id();
-
-// Only run this on SNG7
-if ($distro['pbx_type'] === "freepbxdistro" && FreePBX::Modules()->checkStatus("sysadmin")) {
-	if (!file_exists('/etc/pki/ca-trust/source/blacklist/DST-Root-CA-X3.pem')) {
-		FreePBX::Certman()->runHook("fix-le-root-ca");
+// Self-heal: install.php runs as root during "fwconsole ma install", so reconcile
+// any managed CAs back into the system trust store (e.g. after an OS update wiped
+// the anchors). Safe no-op when there is nothing managed.
+try {
+	if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+		FreePBX::Certman()->reconcileSystemCAs();
 	}
+} catch (\Exception $e) {
+	dbug("certman install: reconcileSystemCAs failed: " . $e->getMessage());
 }

--- a/module.xml
+++ b/module.xml
@@ -2,7 +2,7 @@
 	<rawname>certman</rawname>
 	<name>Certificate Manager</name>
 	<repo>standard</repo>
-	<version>17.0.3.14</version>
+	<version>17.0.3.15</version>
 	<publisher>Sangoma Technologies Corporation</publisher>
 	<license>AGPLv3+</license>
 	<licenselink>http://www.gnu.org/licenses/agpl-3.0.txt</licenselink>
@@ -14,7 +14,8 @@
 	</description>
 	<more-info>https://sangomakb.atlassian.net/wiki/spaces/PG/pages/20775139/PBX+GUI+-+Certificate+Management+Module</more-info>
 	<changelog>
-		*17.0.3.14* FREEI-2385 fix:Integrate HAProxy reload into certificate renewal process for Let's Encrypt certificates 
+		*17.0.3.15* feat: Add private ACME server support, installed-CA viewer and web/CLI option to install a CA certificate into the system trust store (via privileged sysadmin hook).
+		*17.0.3.14* FREEI-2385 fix:Integrate HAProxy reload into certificate renewal process for Let's Encrypt certificates
 		*17.0.3.13* Packaging of ver 17.0.3.13
 		*17.0.1alpha* 17.0.1 alpha release
 	</changelog>

--- a/views/certgrid.php
+++ b/views/certgrid.php
@@ -20,6 +20,7 @@
 		<a href="?display=certman&amp;certaction=delete&amp;type=ca" class="btn btn-danger" id="delCA"><i class="fa fa-times"></i> <?php echo _("Delete Self-Signed CA")?></a>
 	<?php } ?>
 	<a href="?display=certman&amp;certaction=importlocally" class="btn btn-primary"><?php echo _("Import Locally")?></a>
+	<a href="?display=certman&amp;action=systemcas" class="btn btn-default"><i class="fa fa-certificate"></i> <?php echo _("Installed CAs")?></a>
 </div>
 <table data-toolbar="#toolbar-all" data-maintain-selected="true" data-show-columns="true" data-show-toggle="true" data-toggle="table" data-pagination="true" data-search="true" class="table table-striped">
 	<thead>

--- a/views/le.php
+++ b/views/le.php
@@ -61,7 +61,7 @@ $alert .= "</div>";
 												<i class="fa fa-question-circle fpbx-help-icon" data-for="email"></i>
 											</div>
 											<div class="col-md-9">
-												<input type="text" class="form-control" id="email" name="email" placeholder="you@example.com" required value="<?php echo $cert['additional']['email'] ?? ""; ?>">
+												<input type="text" class="form-control" id="email" name="email" placeholder="you@example.com" value="<?php echo $cert['additional']['email'] ?? ""; ?>">
 											</div>
 										</div>
 										<div class="col-md-12">
@@ -196,25 +196,6 @@ $alert .= "</div>";
 									</div>
 								</div>
 								<!-- END Custom / Private ACME server -->
-
-								<!-- Remove DST Root CA X3 -->
-								<div class="element-container">
-									<div class="row">
-										<div class="form-group form-horizontal">
-											<div class="col-md-3">
-												<label class="control-label" for="removeDstRootCaX3"><?php echo _("Remove DST Root CA X3")?></label>
-												<i class="fa fa-question-circle fpbx-help-icon" data-for="removeDstRootCaX3"></i>
-											</div>
-											<div class="col-md-9">
-												<input type="checkbox" id="removeDstRootCaX3" name="removeDstRootCaX3" <?php echo (!empty($cert['additional']['removeDstRootCaX3']) && $cert['additional']['removeDstRootCaX3'] ? "checked" : ""); ?>>
-											</div>
-										</div>
-										<div class="col-md-12">
-											<span id="removeDstRootCaX3-help" class="help-block fpbx-help-block"><?php echo _("The Let's Encrypt bundled 'DST Root CA X3' can cause issues with older clients. This option removes the 'DST Root CA X3' from the certificate bundle.")?></span>
-										</div>
-									</div>
-								</div>
-								<!-- END DST Root CA X3 -->
 							</div>
 							<!-- END Section -->
 
@@ -298,3 +279,119 @@ $alert .= "</div>";
 		</div>
 	</div>
 </div>
+
+<!-- Background Let's Encrypt generation: progress modal -->
+<div class="modal fade" id="leGenModal" tabindex="-1" role="dialog" aria-labelledby="leGenModalLabel">
+	<div class="modal-dialog modal-lg" role="document">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h4 class="modal-title" id="leGenModalLabel"><i class="fa fa-certificate"></i> <?php echo _("Generating Let's Encrypt Certificate")?></h4>
+			</div>
+			<div class="modal-body">
+				<p id="leGenStatus"><i class="fa fa-spinner fa-spin"></i> <?php echo _("Starting...")?></p>
+				<div class="progress" style="margin-bottom:10px;">
+					<div id="leGenBar" class="progress-bar progress-bar-striped active" role="progressbar" style="width:100%;"></div>
+				</div>
+				<label class="control-label"><?php echo _("Output")?></label>
+				<pre id="leGenLog" style="margin-top:5px; min-height:80px; max-height:320px; overflow:auto; white-space:pre-wrap; word-break:break-all;"><?php echo _("Waiting for output...")?></pre>
+			</div>
+			<div class="modal-footer">
+				<button type="button" class="btn btn-default" id="leGenClose" data-dismiss="modal" style="display:none;"><?php echo _("Close")?></button>
+			</div>
+		</div>
+	</div>
+</div>
+
+<script type="text/javascript">
+(function(){
+	// certman.js disables the action-bar Submit button and changes its label to
+	// "Generating... Please wait" on every form submit. Because we handle the
+	// generation via AJAX, restore it when the operation fails or the modal closes.
+	var leGenSubmitVal = '';
+	function leGenResetSubmit(){ $('#Submit').val(leGenSubmitVal).prop('disabled', false); }
+
+	// Progress bar state: 'running' (animated), 'success' (green 100%), 'error' (red 100%).
+	// Colours are forced inline because the theme styles .progress-bar with its own
+	// brand colour/stripes at a higher specificity than the Bootstrap state classes.
+	function leGenBarState(state){
+		var bar = $('#leGenBar');
+		bar.removeClass('progress-bar-striped active progress-bar-success progress-bar-danger').css('width','100%');
+		if(state === 'success'){
+			bar.addClass('progress-bar-success').css({'background-color':'#5cb85c','background-image':'none'});
+		} else if(state === 'error'){
+			bar.addClass('progress-bar-danger').css({'background-color':'#d9534f','background-image':'none'});
+		} else {
+			bar.addClass('progress-bar-striped active').css({'background-color':'','background-image':''});
+		}
+	}
+
+	function leGenPoll(host){
+		$.get('ajax.php?module=certman&command=generateLEStatus&host='+encodeURIComponent(host), function(res){
+			if(res && typeof res.log === 'string'){
+				var el = document.getElementById('leGenLog');
+				el.textContent = res.log.trim() !== '' ? res.log : '<?php echo _("Waiting for output...")?>';
+				el.scrollTop = el.scrollHeight;
+			}
+			if(res && res.finished){
+				if(res.success){
+					leGenBarState('success');
+					$('#leGenStatus').html('<i class="fa fa-check text-success"></i> <?php echo _("Certificate generated successfully. Redirecting...")?>');
+					setTimeout(function(){ window.location = 'config.php?display=certman'; }, 1500);
+				} else {
+					leGenBarState('error');
+					$('#leGenStatus').html('<i class="fa fa-times text-danger"></i> <?php echo _("Generation failed. See the log below.")?>');
+					$('#leGenClose').show();
+					leGenResetSubmit();
+				}
+				return;
+			}
+			$('#leGenStatus').html('<i class="fa fa-spinner fa-spin"></i> <?php echo _("Generating certificate, please wait. This can take a minute...")?>');
+			setTimeout(function(){ leGenPoll(host); }, 2000);
+		}, 'json').fail(function(){
+			setTimeout(function(){ leGenPoll(host); }, 3000);
+		});
+	}
+
+	$(document).ready(function(){
+		leGenSubmitVal = $('#Submit').val();
+		$('#leGenModal').on('hidden.bs.modal', leGenResetSubmit);
+		$('form[name=frm_certman]').on('submit', function(e){
+			// Intercept both new generation and edits of existing LE certificates.
+			var leAct = $('#certaction').val();
+			if(leAct !== 'add' && leAct !== 'edit'){ return true; }
+			if(this.checkValidity && !this.checkValidity()){
+				e.preventDefault();
+				if(this.reportValidity){ this.reportValidity(); }
+				return false;
+			}
+			e.preventDefault();
+			var form = this;
+			var host = ($('#host').val()||'').toLowerCase();
+			$('#leGenLog').text('<?php echo _("Waiting for output...")?>');
+			$('#leGenStatus').html('<i class="fa fa-spinner fa-spin"></i> <?php echo _("Starting...")?>');
+			$('#leGenClose').hide();
+			leGenBarState('running');
+			$('#leGenModal').modal({backdrop:'static', keyboard:false});
+			$('#leGenModal').modal('show');
+			$.post('ajax.php?module=certman&command=generateLEStart', $(form).serialize(), function(res){
+				if(!res || !res.status){
+					leGenBarState('error');
+					$('#leGenStatus').html('<i class="fa fa-times text-danger"></i> <?php echo _("Generation failed.")?>');
+					$('#leGenLog').text((res&&res.message)?res.message:'<?php echo _("Could not start generation.")?>');
+					$('#leGenClose').show();
+					leGenResetSubmit();
+					return;
+				}
+				leGenPoll(res.host || host);
+			}, 'json').fail(function(){
+				leGenBarState('error');
+				$('#leGenStatus').html('<i class="fa fa-times text-danger"></i> <?php echo _("Generation failed.")?>');
+				$('#leGenLog').text('<?php echo _("Could not start generation.")?>');
+				$('#leGenClose').show();
+				leGenResetSubmit();
+			});
+			return false;
+		});
+	});
+})();
+</script>

--- a/views/le.php
+++ b/views/le.php
@@ -139,6 +139,64 @@ $alert .= "</div>";
 								</div>
 								<!-- END Challenge Method -->
 
+								<!-- Custom / Private ACME server -->
+								<?php
+									$acmeUrl = $cert['additional']['acmeUrl'] ?? '';
+									$acmeCa  = $cert['additional']['acmeCaBundle'] ?? '';
+									$acmeInsecure = !empty($cert['additional']['acmeInsecure']);
+								?>
+								<div class="element-container">
+									<div class="row">
+										<div class="form-group form-horizontal">
+											<div class="col-md-3">
+												<label class="control-label" for="acme_url"><?php echo _("Custom ACME Server URL")?></label>
+												<i class="fa fa-question-circle fpbx-help-icon" data-for="acme_url"></i>
+											</div>
+											<div class="col-md-9">
+												<input type="text" class="form-control" id="acme_url" name="acme_url" placeholder="https://acme.internal.example.com/acme/acme/directory" value="<?php echo htmlspecialchars($acmeUrl, ENT_QUOTES); ?>">
+											</div>
+										</div>
+										<div class="col-md-12">
+											<span id="acme_url-help" class="help-block fpbx-help-block"><?php echo _("Leave empty to use the public Let's Encrypt service. To use a private/self-hosted ACME server, enter the full ACME <strong>directory</strong> URL (e.g. step-ca: <code>/acme/&lt;provisioner&gt;/directory</code>, Pebble: <code>/dir</code>). Validation still uses the http-01 challenge on port 80.")?></span>
+										</div>
+									</div>
+								</div>
+
+								<div class="element-container">
+									<div class="row">
+										<div class="form-group form-horizontal">
+											<div class="col-md-3">
+												<label class="control-label" for="acme_ca"><?php echo _("ACME Server CA Bundle")?></label>
+												<i class="fa fa-question-circle fpbx-help-icon" data-for="acme_ca"></i>
+											</div>
+											<div class="col-md-9">
+												<input type="text" class="form-control" id="acme_ca" name="acme_ca" placeholder="/etc/ssl/certs/internal-ca.pem" value="<?php echo htmlspecialchars($acmeCa, ENT_QUOTES); ?>">
+											</div>
+										</div>
+										<div class="col-md-12">
+											<span id="acme_ca-help" class="help-block fpbx-help-block"><?php echo _("Optional. Only needed when the custom ACME server presents a TLS certificate signed by a private CA that this server does not already trust. You have three options, pick one: (1) install that CA into the system trust store from the <strong>Installed CAs</strong> page and leave this field empty; (2) enter here the path to a PEM CA bundle that signs the ACME server certificate; or (3) enable <strong>Skip ACME Server TLS Verification</strong> below. Leave empty for the public Let's Encrypt service.")?></span>
+										</div>
+									</div>
+								</div>
+
+								<div class="element-container">
+									<div class="row">
+										<div class="form-group form-horizontal">
+											<div class="col-md-3">
+												<label class="control-label" for="acme_insecure"><?php echo _("Skip ACME Server TLS Verification")?></label>
+												<i class="fa fa-question-circle fpbx-help-icon" data-for="acme_insecure"></i>
+											</div>
+											<div class="col-md-9">
+												<input type="checkbox" id="acme_insecure" name="acme_insecure" <?php echo ($acmeInsecure ? "checked" : ""); ?>>
+											</div>
+										</div>
+										<div class="col-md-12">
+											<span id="acme_insecure-help" class="help-block fpbx-help-block"><?php echo _("Disable TLS certificate verification when connecting to the custom ACME server. Use only for self-signed servers on a trusted network when no CA bundle is available. Ignored for the public Let's Encrypt service.")?></span>
+										</div>
+									</div>
+								</div>
+								<!-- END Custom / Private ACME server -->
+
 								<!-- Remove DST Root CA X3 -->
 								<div class="element-container">
 									<div class="row">

--- a/views/rnav.php
+++ b/views/rnav.php
@@ -1,5 +1,6 @@
 <div id="toolbar-certman">
 	<a href='?display=certman' class="btn btn-default"><i class="fa fa-th-list"></i>&nbsp;&nbsp;<?php echo _('Certificate List')?></a>
+    <a href='?display=certman&action=systemcas' class="btn btn-default"><i class="fa fa-th-list"></i>&nbsp;&nbsp;<?php echo _("Installed CA's")?></a>
 </div>
 <table data-url="ajax.php?module=certman&command=getJSON&jdata=grid" data-cache="false" data-toggle="table" data-toolbar="#toolbar-certman" data-search="true" class="table" id="table-all-side">
     <thead>

--- a/views/systemcas.php
+++ b/views/systemcas.php
@@ -1,0 +1,150 @@
+<?php
+//	License for all code of this FreePBX module can be found in the license file inside the module directory
+$sources = $systemcas['sources'] ?? array();
+$cas = $systemcas['cas'] ?? array();
+$now = time();
+?>
+<div class="container-fluid">
+	<h1><?php echo _('Installed Certificate Authorities')?></h1>
+
+	<?php if(!empty($message) && !empty($message['message'])) { ?>
+		<div class="alert alert-<?php echo htmlspecialchars($message['type'] ?? 'info', ENT_QUOTES); ?> alert-dismissable">
+			<span class="fa fa-times close" data-dismiss="alert" aria-hidden="true"></span>
+			<?php echo $message['message']; ?>
+		</div>
+	<?php } ?>
+
+	<div class="alert alert-info">
+		<?php echo _("These are the CA certificates trusted by this server (the same trust store used by PHP/cURL for outbound TLS). Use this list to confirm that a private/self-hosted ACME server's CA is already trusted, and to find a CA bundle path for the \"ACME Server CA Bundle\" field when generating a Let's Encrypt certificate.")?>
+	</div>
+
+	<!-- Install a CA into the system trust store (collapsible) -->
+	<div class="panel panel-default">
+		<div class="panel-heading" style="cursor:pointer;" data-toggle="collapse" data-target="#install-ca-body" aria-expanded="false">
+			<div class="panel-title">
+				<i class="fa fa-upload"></i>&nbsp;<?php echo _("Install a CA Certificate")?>
+				<i class="fa fa-chevron-down pull-right"></i>
+			</div>
+		</div>
+		<div class="panel-body collapse" id="install-ca-body">
+		<div class="alert alert-warning">
+			<?php echo _("This installs the certificate into the operating system trust store, so it becomes trusted system-wide (cURL, PHP, etc.). Only install CA certificates you trust: a malicious CA can be used to intercept TLS traffic. This requires the Sysadmin module (the install runs as root).")?>
+		</div>
+		<form class="" name="frm_installca" action="config.php?display=certman&amp;action=systemcas" method="post" enctype="multipart/form-data">
+			<input type="hidden" name="certaction" value="installca">
+			<div class="element-container">
+				<div class="row">
+					<div class="form-group form-horizontal">
+						<div class="col-md-3"><label class="control-label" for="ca_name"><?php echo _("Friendly Name")?></label></div>
+						<div class="col-md-9">
+							<input type="text" class="form-control" id="ca_name" name="ca_name" placeholder="internal-acme-ca">
+							<span class="help-block fpbx-help-block"><?php echo _("Optional. Used for the stored filename (it will be prefixed with 'certman-'). Defaults to the certificate Common Name.")?></span>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="element-container">
+				<div class="row">
+					<div class="form-group form-horizontal">
+						<div class="col-md-3"><label class="control-label" for="ca_pem"><?php echo _("CA Certificate (PEM)")?></label></div>
+						<div class="col-md-9">
+							<textarea class="form-control" id="ca_pem" name="ca_pem" rows="8" placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"></textarea>
+							<span class="help-block fpbx-help-block"><?php echo _("Paste the PEM encoded CA certificate, or upload a file below. If both are provided, the uploaded file is used.")?></span>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="element-container">
+				<div class="row">
+					<div class="form-group form-horizontal">
+						<div class="col-md-3"><label class="control-label" for="ca_file"><?php echo _("Or Upload File")?></label></div>
+						<div class="col-md-9">
+							<input type="file" id="ca_file" name="ca_file" accept=".pem,.crt,.cer">
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="element-container">
+				<div class="row">
+					<div class="col-md-9 col-md-offset-3">
+						<button type="submit" class="btn btn-primary"><i class="fa fa-upload"></i> <?php echo _("Install CA")?></button>
+					</div>
+				</div>
+			</div>
+		</form>
+		</div>
+	</div>
+
+	<div class="display full-border">
+		<!-- Trust stores -->
+		<div class="section-title"><h3><i class="fa fa-folder-open"></i>&nbsp;<?php echo _("Trust Stores")?></h3></div>
+		<table class="table table-striped">
+			<thead>
+				<tr>
+					<th><?php echo _("Path")?></th>
+					<th><?php echo _("Description")?></th>
+					<th><?php echo _("Status")?></th>
+					<th><?php echo _("Certificates")?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach($sources as $s) { ?>
+					<tr>
+						<td><code><?php echo htmlspecialchars($s['path'], ENT_QUOTES); ?></code></td>
+						<td><?php echo htmlspecialchars($s['label'], ENT_QUOTES); ?></td>
+						<td>
+							<?php if(!empty($s['exists'])) { ?>
+								<span class="label label-success"><?php echo _("Present")?></span>
+							<?php } else { ?>
+								<span class="label label-default"><?php echo _("Not found")?></span>
+							<?php } ?>
+						</td>
+						<td><?php echo (int)$s['count']; ?></td>
+					</tr>
+				<?php } ?>
+			</tbody>
+		</table>
+
+		<!-- CA certificates -->
+		<div class="section-title"><h3><i class="fa fa-certificate"></i>&nbsp;<?php echo sprintf(_("Trusted CA Certificates (%d)"), count($cas))?></h3></div>
+		<table data-toggle="table" data-pagination="true" data-page-size="25" data-search="true" data-show-columns="true" class="table table-striped">
+			<thead>
+				<tr>
+					<th data-sortable="true"><?php echo _("Common Name / Organization")?></th>
+					<th data-sortable="true"><?php echo _("Issuer")?></th>
+					<th data-sortable="true"><?php echo _("Type")?></th>
+					<th data-sortable="true" data-field="expires"><?php echo _("Expires")?></th>
+					<th><?php echo _("SHA1 Fingerprint")?></th>
+					<th><?php echo _("Source File")?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach($cas as $ca) {
+					$expired = (!empty($ca['validTo_time_t']) && $ca['validTo_time_t'] < $now);
+				?>
+					<tr>
+						<td><strong><?php echo htmlspecialchars($ca['cn'], ENT_QUOTES); ?></strong>
+							<i class="fa fa-question-circle fpbx-help-icon" title="<?php echo htmlspecialchars($ca['subject'], ENT_QUOTES); ?>"></i>
+						</td>
+						<td><?php echo htmlspecialchars($ca['issuer'], ENT_QUOTES); ?></td>
+						<td>
+							<?php if(!empty($ca['selfSigned'])) { ?>
+								<span class="label label-primary"><?php echo _("Root (self-signed)")?></span>
+							<?php } else { ?>
+								<span class="label label-info"><?php echo _("Intermediate")?></span>
+							<?php } ?>
+						</td>
+						<td data-value="<?php echo (int)$ca['validTo_time_t']; ?>">
+							<?php
+								echo !empty($ca['validTo_time_t']) ? date('Y-m-d', $ca['validTo_time_t']) : '-';
+								if($expired) { echo ' <span class="label label-danger">'._("Expired").'</span>'; }
+							?>
+						</td>
+						<td><small><code><?php echo htmlspecialchars($ca['fingerprint'], ENT_QUOTES); ?></code></small></td>
+						<td><small><?php echo htmlspecialchars($ca['source'], ENT_QUOTES); ?></small></td>
+					</tr>
+				<?php } ?>
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/views/systemcas.php
+++ b/views/systemcas.php
@@ -2,7 +2,10 @@
 //	License for all code of this FreePBX module can be found in the license file inside the module directory
 $sources = $systemcas['sources'] ?? array();
 $cas = $systemcas['cas'] ?? array();
+$managed = $managed ?? array();
 $now = time();
+$driftCount = 0;
+foreach($managed as $m) { if(!empty($m['wantInstall']) !== !empty($m['present'])) { $driftCount++; } }
 ?>
 <div class="container-fluid">
 	<h1><?php echo _('Installed Certificate Authorities')?></h1>
@@ -18,65 +21,64 @@ $now = time();
 		<?php echo _("These are the CA certificates trusted by this server (the same trust store used by PHP/cURL for outbound TLS). Use this list to confirm that a private/self-hosted ACME server's CA is already trusted, and to find a CA bundle path for the \"ACME Server CA Bundle\" field when generating a Let's Encrypt certificate.")?>
 	</div>
 
-	<!-- Install a CA into the system trust store (collapsible) -->
-	<div class="panel panel-default">
-		<div class="panel-heading" style="cursor:pointer;" data-toggle="collapse" data-target="#install-ca-body" aria-expanded="false">
-			<div class="panel-title">
-				<i class="fa fa-upload"></i>&nbsp;<?php echo _("Install a CA Certificate")?>
-				<i class="fa fa-chevron-down pull-right"></i>
-			</div>
-		</div>
-		<div class="panel-body collapse" id="install-ca-body">
-		<div class="alert alert-warning">
-			<?php echo _("This installs the certificate into the operating system trust store, so it becomes trusted system-wide (cURL, PHP, etc.). Only install CA certificates you trust: a malicious CA can be used to intercept TLS traffic. This requires the Sysadmin module (the install runs as root).")?>
-		</div>
-		<form class="" name="frm_installca" action="config.php?display=certman&amp;action=systemcas" method="post" enctype="multipart/form-data">
-			<input type="hidden" name="certaction" value="installca">
-			<div class="element-container">
-				<div class="row">
-					<div class="form-group form-horizontal">
-						<div class="col-md-3"><label class="control-label" for="ca_name"><?php echo _("Friendly Name")?></label></div>
-						<div class="col-md-9">
-							<input type="text" class="form-control" id="ca_name" name="ca_name" placeholder="internal-acme-ca">
-							<span class="help-block fpbx-help-block"><?php echo _("Optional. Used for the stored filename (it will be prefixed with 'certman-'). Defaults to the certificate Common Name.")?></span>
+	<!-- Modal: load a CA certificate into Certman (step 1) -->
+	<div class="modal fade" id="loadCaModal" tabindex="-1" role="dialog" aria-labelledby="loadCaModalLabel">
+		<div class="modal-dialog modal-lg" role="document">
+			<div class="modal-content">
+				<form name="frm_installca" action="config.php?display=certman&amp;action=systemcas" method="post" enctype="multipart/form-data">
+					<input type="hidden" name="certaction" value="savecert">
+					<div class="modal-header">
+						<button type="button" class="close" data-dismiss="modal" aria-label="<?php echo _("Close")?>"><span aria-hidden="true">&times;</span></button>
+						<h4 class="modal-title" id="loadCaModalLabel"><i class="fa fa-upload"></i> <?php echo _("Load a CA Certificate")?></h4>
+					</div>
+					<div class="modal-body">
+						<div class="alert alert-info">
+							<?php echo _("Step 1 of 2. This loads the certificate into Certman but does NOT install it into the system trust store yet. After loading it, use the Install button in the list below to add it to the operating-system trust store. Only trust CA certificates you control: a malicious CA can be used to intercept TLS traffic.")?>
+						</div>
+						<div class="element-container">
+							<div class="row">
+								<div class="form-group form-horizontal">
+									<div class="col-md-3"><label class="control-label" for="ca_name"><?php echo _("Friendly Name")?></label></div>
+									<div class="col-md-9">
+										<input type="text" class="form-control" id="ca_name" name="ca_name" placeholder="internal-acme-ca">
+										<span class="help-block fpbx-help-block"><?php echo _("Optional. Used for the stored filename (it will be prefixed with 'certman-'). Defaults to the certificate Common Name.")?></span>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="element-container">
+							<div class="row">
+								<div class="form-group form-horizontal">
+									<div class="col-md-3"><label class="control-label" for="ca_pem"><?php echo _("CA Certificate (PEM)")?></label></div>
+									<div class="col-md-9">
+										<textarea class="form-control" id="ca_pem" name="ca_pem" rows="8" placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"></textarea>
+										<span class="help-block fpbx-help-block"><?php echo _("Paste the PEM encoded CA certificate, or upload a file below. If both are provided, the uploaded file is used.")?></span>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="element-container">
+							<div class="row">
+								<div class="form-group form-horizontal">
+									<div class="col-md-3"><label class="control-label" for="ca_file"><?php echo _("Or Upload File")?></label></div>
+									<div class="col-md-9">
+										<input type="file" id="ca_file" name="ca_file" accept=".pem,.crt,.cer">
+									</div>
+								</div>
+							</div>
 						</div>
 					</div>
-				</div>
-			</div>
-			<div class="element-container">
-				<div class="row">
-					<div class="form-group form-horizontal">
-						<div class="col-md-3"><label class="control-label" for="ca_pem"><?php echo _("CA Certificate (PEM)")?></label></div>
-						<div class="col-md-9">
-							<textarea class="form-control" id="ca_pem" name="ca_pem" rows="8" placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"></textarea>
-							<span class="help-block fpbx-help-block"><?php echo _("Paste the PEM encoded CA certificate, or upload a file below. If both are provided, the uploaded file is used.")?></span>
-						</div>
+					<div class="modal-footer">
+						<button type="button" class="btn btn-default" data-dismiss="modal"><?php echo _("Cancel")?></button>
+						<button type="submit" class="btn btn-primary"><i class="fa fa-upload"></i> <?php echo _("Load CA")?></button>
 					</div>
-				</div>
+				</form>
 			</div>
-			<div class="element-container">
-				<div class="row">
-					<div class="form-group form-horizontal">
-						<div class="col-md-3"><label class="control-label" for="ca_file"><?php echo _("Or Upload File")?></label></div>
-						<div class="col-md-9">
-							<input type="file" id="ca_file" name="ca_file" accept=".pem,.crt,.cer">
-						</div>
-					</div>
-				</div>
-			</div>
-			<div class="element-container">
-				<div class="row">
-					<div class="col-md-9 col-md-offset-3">
-						<button type="submit" class="btn btn-primary"><i class="fa fa-upload"></i> <?php echo _("Install CA")?></button>
-					</div>
-				</div>
-			</div>
-		</form>
 		</div>
 	</div>
 
+	<!-- Trust stores (summary) -->
 	<div class="display full-border">
-		<!-- Trust stores -->
 		<div class="section-title"><h3><i class="fa fa-folder-open"></i>&nbsp;<?php echo _("Trust Stores")?></h3></div>
 		<table class="table table-striped">
 			<thead>
@@ -104,47 +106,100 @@ $now = time();
 				<?php } ?>
 			</tbody>
 		</table>
+	</div>
 
-		<!-- CA certificates -->
-		<div class="section-title"><h3><i class="fa fa-certificate"></i>&nbsp;<?php echo sprintf(_("Trusted CA Certificates (%d)"), count($cas))?></h3></div>
-		<table data-toggle="table" data-pagination="true" data-page-size="25" data-search="true" data-show-columns="true" class="table table-striped">
+	<!-- CAs loaded into Certman (desired state) -->
+	<div class="display full-border">
+		<div class="section-title"><h3><i class="fa fa-shield"></i>&nbsp;<?php echo sprintf(_("CAs Loaded into Certman (%d)"), count($managed))?></h3></div>
+		<?php if($driftCount > 0) { ?>
+			<div class="alert alert-warning">
+				<i class="fa fa-exclamation-triangle"></i>
+				<?php echo sprintf(_("%d CA(s) are out of sync with the system trust store (marked for install but missing, or marked for uninstall but still present)."), $driftCount); ?>
+				<form style="display:inline" method="post" action="config.php?display=certman&amp;action=systemcas">
+					<input type="hidden" name="certaction" value="reinstallca">
+					<button type="submit" class="btn btn-xs btn-warning"><i class="fa fa-refresh"></i> <?php echo _("Reconcile now")?></button>
+				</form>
+			</div>
+		<?php } ?>
+		<!-- Custom toolbar: the Load button renders to the left of the search box -->
+		<div id="caLoadedToolbar">
+			<button type="button" class="btn btn-primary" data-toggle="modal" data-target="#loadCaModal">
+				<i class="fa fa-upload"></i> <?php echo _("Load a CA Certificate")?>
+			</button>
+		</div>
+		<table data-toggle="table" data-search="true" data-toolbar="#caLoadedToolbar" data-cache="false" data-show-refresh="true"
+		       data-url="ajax.php?module=certman&amp;command=getManagedCAsGrid" class="table table-striped">
 			<thead>
 				<tr>
-					<th data-sortable="true"><?php echo _("Common Name / Organization")?></th>
-					<th data-sortable="true"><?php echo _("Issuer")?></th>
-					<th data-sortable="true"><?php echo _("Type")?></th>
-					<th data-sortable="true" data-field="expires"><?php echo _("Expires")?></th>
-					<th><?php echo _("SHA1 Fingerprint")?></th>
-					<th><?php echo _("Source File")?></th>
+					<th data-field="cn" data-sortable="true" data-formatter="caCnFmt"><?php echo _("Common Name")?></th>
+					<th data-field="fingerprint" data-sortable="true" data-formatter="caFpFmt"><?php echo _("SHA1 Fingerprint")?></th>
+					<th data-field="wantInstall" data-sortable="true" data-halign="center" data-align="center" data-formatter="caDesiredFmt"><?php echo _("Desired")?></th>
+					<th data-field="present" data-sortable="true" data-halign="center" data-align="center" data-formatter="caPresentFmt"><?php echo _("In System Trust Store")?></th>
+					<th data-field="fp" data-searchable="false" data-halign="center" data-align="center" data-width="240" data-formatter="caActionsFmt"><?php echo _("Actions")?></th>
 				</tr>
 			</thead>
-			<tbody>
-				<?php foreach($cas as $ca) {
-					$expired = (!empty($ca['validTo_time_t']) && $ca['validTo_time_t'] < $now);
-				?>
-					<tr>
-						<td><strong><?php echo htmlspecialchars($ca['cn'], ENT_QUOTES); ?></strong>
-							<i class="fa fa-question-circle fpbx-help-icon" title="<?php echo htmlspecialchars($ca['subject'], ENT_QUOTES); ?>"></i>
-						</td>
-						<td><?php echo htmlspecialchars($ca['issuer'], ENT_QUOTES); ?></td>
-						<td>
-							<?php if(!empty($ca['selfSigned'])) { ?>
-								<span class="label label-primary"><?php echo _("Root (self-signed)")?></span>
-							<?php } else { ?>
-								<span class="label label-info"><?php echo _("Intermediate")?></span>
-							<?php } ?>
-						</td>
-						<td data-value="<?php echo (int)$ca['validTo_time_t']; ?>">
-							<?php
-								echo !empty($ca['validTo_time_t']) ? date('Y-m-d', $ca['validTo_time_t']) : '-';
-								if($expired) { echo ' <span class="label label-danger">'._("Expired").'</span>'; }
-							?>
-						</td>
-						<td><small><code><?php echo htmlspecialchars($ca['fingerprint'], ENT_QUOTES); ?></code></small></td>
-						<td><small><?php echo htmlspecialchars($ca['source'], ENT_QUOTES); ?></small></td>
-					</tr>
-				<?php } ?>
-			</tbody>
 		</table>
 	</div>
+	<br>
+
+	<!-- All CA certificates trusted by the system -->
+	<div class="display full-border">
+		<div class="section-title"><h3><i class="fa fa-certificate"></i>&nbsp;<?php echo sprintf(_("Trusted CA Certificates (%d)"), count($cas))?></h3></div>
+		<table data-toggle="table" data-pagination="true" data-page-size="25" data-search="true" data-show-columns="true" data-show-refresh="true" data-cache="false"
+		       data-url="ajax.php?module=certman&amp;command=getSystemCAsGrid" class="table table-striped">
+			<thead>
+				<tr>
+					<th data-field="cn" data-sortable="true" data-formatter="caCnSysFmt"><?php echo _("Common Name / Organization")?></th>
+					<th data-field="issuer" data-sortable="true"><?php echo _("Issuer")?></th>
+					<th data-field="selfSigned" data-sortable="true" data-formatter="caTypeFmt"><?php echo _("Type")?></th>
+					<th data-field="expires" data-sortable="true" data-formatter="caExpiresFmt"><?php echo _("Expires")?></th>
+					<th data-field="fingerprint" data-formatter="caFpFmt"><?php echo _("SHA1 Fingerprint")?></th>
+					<th data-field="source" data-formatter="caSrcFmt"><?php echo _("Source File")?></th>
+				</tr>
+			</thead>
+		</table>
+	</div>
+
 </div>
+
+<script type="text/javascript">
+	// Escape helper (renders text safely inside the bootstrap-table formatters).
+	function certmanEsc(s){ return $('<div>').text(s == null ? '' : s).html(); }
+	var CERTMAN_SYSACTION = 'config.php?display=certman&action=systemcas';
+
+	// "CAs Loaded into Certman" formatters
+	function caCnFmt(v,r){ return '<strong>'+certmanEsc(v)+'</strong>'; }
+	function caFpFmt(v,r){ return '<small><code>'+certmanEsc(v)+'</code></small>'; }
+	function caSrcFmt(v,r){ return '<small>'+certmanEsc(v)+'</small>'; }
+	function caDesiredFmt(v,r){
+		return r.wantInstall
+			? '<span class="label label-info"><?php echo _("Install")?></span>'
+			: '<span class="label label-default"><?php echo _("Loaded only")?></span>';
+	}
+	function caPresentFmt(v,r){
+		return r.present
+			? '<span class="label label-success"><i class="fa fa-check"></i> <?php echo _("Present")?></span>'
+			: '<span class="label label-default"><?php echo _("Not present")?></span>';
+	}
+	function caActionsFmt(v,r){
+		var fp = certmanEsc(r.fp);
+		var toggle = r.wantInstall
+			? '<form style="display:inline-block" method="post" action="'+CERTMAN_SYSACTION+'"><input type="hidden" name="certaction" value="uninstallca"><input type="hidden" name="fp" value="'+fp+'"><button type="submit" class="btn btn-xs btn-warning"><i class="fa fa-sign-out"></i> <?php echo _("Uninstall")?></button></form>'
+			: '<form style="display:inline-block" method="post" action="'+CERTMAN_SYSACTION+'"><input type="hidden" name="certaction" value="installca"><input type="hidden" name="fp" value="'+fp+'"><button type="submit" class="btn btn-xs btn-primary"><i class="fa fa-download"></i> <?php echo _("Install")?></button></form>';
+		var remove = '<form style="display:inline-block" method="post" action="'+CERTMAN_SYSACTION+'" onsubmit="return confirm(\'<?php echo _("Remove this CA from Certman entirely (and uninstall it from the system)?")?>\');"><input type="hidden" name="certaction" value="removeca"><input type="hidden" name="fp" value="'+fp+'"><button type="submit" class="btn btn-xs btn-danger"><i class="fa fa-trash"></i> <?php echo _("Remove")?></button></form>';
+		return '<div style="white-space:nowrap;">' + toggle + ' ' + remove + '</div>';
+	}
+
+	// "Trusted CA Certificates" formatters
+	function caCnSysFmt(v,r){
+		return '<strong>'+certmanEsc(v)+'</strong> <i class="fa fa-question-circle fpbx-help-icon" title="'+certmanEsc(r.subject)+'"></i>';
+	}
+	function caTypeFmt(v,r){
+		return r.selfSigned
+			? '<span class="label label-primary"><?php echo _("Root (self-signed)")?></span>'
+			: '<span class="label label-info"><?php echo _("Intermediate")?></span>';
+	}
+	function caExpiresFmt(v,r){
+		return certmanEsc(v) + (r.expired ? ' <span class="label label-danger"><?php echo _("Expired")?></span>' : '');
+	}
+</script>


### PR DESCRIPTION
## Summary

Adds the ability to issue Let's Encrypt certificates against a **private / self-hosted ACME server** (not only the public service) over the existing `http-01` challenge, plus tooling to manage the CA certificates the server trusts.

Motivation: many deployments run an internal ACME-compatible CA (step-ca, Boulder, Pebble, …) and need certman to talk to it instead of `acme-v02.api.letsencrypt.org`.

## What's included

### 1. Private / self-hosted ACME server support
- New per-certificate fields in the Let's Encrypt form (and `fwconsole` options):
  - **Custom ACME Server URL** — the full ACME *directory* URL. Empty = public Let's Encrypt (unchanged behaviour).
  - **ACME Server CA Bundle** — optional PEM CA bundle for servers whose TLS endpoint is signed by a private CA.
  - **Skip ACME Server TLS Verification** — optional, for self-signed setups on trusted networks.
- New `AcmeHttpClient` transport implementing `Analogic\ACME\ClientInterface` (does **not** patch the vendored `lescript`, so it survives composer updates). It supports an explicit directory URL (so non-standard paths like step-ca's `/acme/<provisioner>/directory` or Pebble's `/dir` work), a custom CA bundle (`CURLOPT_CAINFO`) and an optional insecure mode.
- `updateLE()` points lescript at the configured directory and **skips the public `mirror1.freepbx.org` reachability probe** when a custom server is used (it's only meaningful for the public service). Settings are persisted per certificate and **inherited automatically by the renewal paths** (cron + web).
- CLI: `fwconsole certificates --generate --type le ... --acme-url=<dir> [--acme-ca=<pem>] [--acme-insecure]`.

### 2. Installed-CA viewer
- New **Installed CAs** page (linked from the certificate list) listing the CA certificates trusted by this server: trust-store paths with certificate counts, and a searchable table of each CA (CN, issuer, root/intermediate, expiry, SHA-1 fingerprint, source file).
- Detects the distribution family (Debian vs RHEL) and shows only the relevant trust stores; falls back to showing all when it can't be determined. The active PHP/cURL bundle is always shown.
- Purpose: confirm a private ACME server's CA is already trusted and locate a usable CA bundle path.

### 3. Install a CA into the system trust store (web + CLI)
- A collapsible **Install a CA Certificate** card on the Installed CAs page (paste PEM or upload a file).
- Because the web process is unprivileged, the install runs as root via a new **Sysadmin incron hook** (`hooks/install-ca`): the web side stages the PEM and the hook copies it into the distribution trust anchors and runs `update-ca-trust` / `update-ca-certificates`. Installation is confirmed by re-scanning the trust store by fingerprint.
- CLI: `fwconsole certificates --install-ca=/path/to/ca.pem` (runs the hook directly when root).
- Requires the Sysadmin module; the UI states this clearly.

## Security notes
- Installing a CA into the system trust store is a powerful, admin-only action (a malicious CA enables TLS interception); the form warns about this.
- TLS verification of the ACME server stays **on** by default; "insecure" is opt-in per certificate.

## Files of note
- `Acme/AcmeHttpClient.php` (new) — custom ACME transport.
- `hooks/install-ca` (new) — privileged CA install hook.
- `views/systemcas.php` (new) — Installed CAs page + install form.
- `Certman.class.php`, `Console/Certman.class.php`, `views/le.php`, `views/certgrid.php`, `assets/js/certman.js`, `module.xml`.

## Testing
- Public Let's Encrypt issuance/renewal: unchanged (custom fields empty → original code path).
- Private ACME (step-ca / Pebble) over `http-01`: issued and renewed against the configured directory.
- Installed CAs page renders the trust store on Debian and RHEL family systems.
- CA install via web (Sysadmin hook): **pending** — blocked on an unsigned dev build (see Known limitations). The `fwconsole --install-ca` path (root, no hook) works.

## Known limitations / pending testing

> ⚠️ **CA install into the system trust store is not yet fully verified.**
> The privileged install relies on the Sysadmin incron hook runner, which only
> executes hooks from a **signed** module. On an unsigned/development build of
> this module the `hooks/install-ca` hook did not run, so the end-to-end "Install
> a CA" flow (web upload → root hook → `update-ca-trust`/`update-ca-certificates`)
> still needs to be validated on a properly signed module.
>
> Not affected: the private ACME server support and the Installed-CAs viewer work
> independently of the hook. When running as root, `fwconsole certificates
> --install-ca=<pem>` also bypasses the hook (it invokes the install logic
> directly) and can be used to verify the install path in the meantime.